### PR TITLE
Seed script updates and default db dates

### DIFF
--- a/examples/webshop/config/migrations/1_users.sql
+++ b/examples/webshop/config/migrations/1_users.sql
@@ -11,8 +11,8 @@ CREATE TABLE users (
     reset_password_sent_at timestamp without time zone,
     remember_created_at timestamp without time zone,
     category_counts jsonb,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 -- Indices -------------------------------------------------------

--- a/examples/webshop/config/migrations/2_products.sql
+++ b/examples/webshop/config/migrations/2_products.sql
@@ -16,8 +16,8 @@ CREATE TABLE products (
 
     price           numeric(7,2),
     user_id         bigint REFERENCES users(id),
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 -- Indices -------------------------------------------------------

--- a/examples/webshop/config/migrations/3_customers.sql
+++ b/examples/webshop/config/migrations/3_customers.sql
@@ -10,8 +10,8 @@ CREATE TABLE customers (
     reset_password_token character varying,
     reset_password_sent_at timestamp without time zone,
     remember_created_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 -- Indices -------------------------------------------------------

--- a/examples/webshop/config/migrations/4_purchases.sql
+++ b/examples/webshop/config/migrations/4_purchases.sql
@@ -6,8 +6,8 @@ CREATE TABLE purchases (
     product_id bigint REFERENCES products(id),
     quantity integer,
     returned_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 -- Indices -------------------------------------------------------

--- a/examples/webshop/config/migrations/5_notifications.sql
+++ b/examples/webshop/config/migrations/5_notifications.sql
@@ -6,8 +6,8 @@ CREATE TABLE notifications (
     subject_type character varying,
     subject_id bigint,
     user_id bigint REFERENCES users(id),
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 -- Indices -------------------------------------------------------

--- a/examples/webshop/config/migrations/6_categories.sql
+++ b/examples/webshop/config/migrations/6_categories.sql
@@ -6,8 +6,8 @@ CREATE TABLE categories (
   name          text NOT NULL           CHECK (length(name) < 100),
   description   text                    CHECK (length(description) < 300),
 
-  created_at timestamp without time zone NOT NULL,
-  updated_at timestamp without time zone NOT NULL
+  created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+  updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 ---- create above / drop below ----

--- a/examples/webshop/config/migrations/7_comments.sql
+++ b/examples/webshop/config/migrations/7_comments.sql
@@ -8,8 +8,8 @@ CREATE TABLE comments (
     user_id         bigint REFERENCES users(id),
     reply_to_id     bigint REFERENCES comments(id),
 
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 ---- create above / drop below ----

--- a/examples/webshop/config/migrations/8_chats.sql
+++ b/examples/webshop/config/migrations/8_chats.sql
@@ -6,8 +6,8 @@ CREATE TABLE chats (
 
     reply_to_id     bigint[],
 
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp without time zone NOT NULL DEFAULT NOW()
 );
 
 ---- create above / drop below ----

--- a/examples/webshop/config/seed.js
+++ b/examples/webshop/config/seed.js
@@ -10,9 +10,6 @@ var purchase_count = 100;
 var notifications_count = 100;
 var comments_count = 100;
 
-// ---- add users
-
-var users = [];
 
 for (i = 0; i < 3; i++) {
   var data = {
@@ -21,23 +18,21 @@ for (i = 0; i < 3; i++) {
     phone: fake.phone(),
     email: "user" + i + "@demo.com",
     password: pwd,
-    password_confirmation: pwd,
-    created_at: "now",
-    updated_at: "now",
+    password_confirmation: pwd
   };
 
   var res = graphql(
-    " \
-	mutation { \
-		user(insert: $data) { \
-			id \
-		} \
-	}",
-    { data: data },
-    { user_id: -1 }
+      " \
+      mutation { \
+          users(insert: $data) { \
+              id \
+          } \
+      }",
+      { data: data },
+      { user_id: -1 }
   );
 
-  users.push(res.user);
+  users.push(res.users);
 }
 
 // more fake users with random email id's
@@ -48,24 +43,23 @@ for (i = 0; i < user_count; i++) {
     phone: fake.phone(),
     email: "user_" + i + "_" + fake.email(),
     password: pwd,
-    password_confirmation: pwd,
-    created_at: "now",
-    updated_at: "now",
+    password_confirmation: pwd
   };
 
   var res = graphql(
-    " \
-	mutation { \
-		user(insert: $data) { \
-			id \
-		} \
-	}",
-    { data: data },
-    { user_id: -1 }
+      " \
+      mutation { \
+          users(insert: $data) { \
+              id \
+          } \
+      }",
+      { data: data },
+      { user_id: -1 }
   );
 
-  users.push(res.user);
+  users.push(res.users);
 }
+
 
 // ---- add customers
 
@@ -84,14 +78,14 @@ for (i = 0; i < customer_count; i++) {
   };
 
   var res = graphql(
-    " \
-	mutation { \
-		customer(insert: $data) { \
-			id \
-		} \
-	}",
-    { data: data },
-    { user_id: u.id }
+      " \
+      mutation { \
+          customers(insert: $data) { \
+              id \
+          } \
+      }",
+      { data: data },
+      { user_id: u.id }
   );
 
   customers.push(res.customer);
@@ -103,29 +97,25 @@ var categories = [
   {
     id: 1,
     name: "Beers",
-    description: "Liquid Bread",
-    created_at: "now",
-    updated_at: "now",
+    description: "Liquid Bread"
   },
   {
     id: 2,
     name: "Alcohol",
-    description: "Bad for you!",
-    created_at: "now",
-    updated_at: "now",
+    description: "Bad for you!"
   },
 ];
 
 // ---- add those sections using bulk insert
 
 var res = graphql(
-  " \
-mutation { \
-  categories(insert: $categories) { \
-    id \
-  } \
-}",
-  { categories: categories, user_id: 1 }
+    " \
+  mutation { \
+    categories(insert: $categories) { \
+      id \
+    } \
+  }",
+    { categories: categories, user_id: 1 }
 );
 
 // ---- add products
@@ -137,34 +127,34 @@ for (i = 0; i < product_count; i++) {
   var u = users[Math.floor(Math.random() * user_count)];
 
   // categories needs connecting since they are
-  // a related to items in a diffent table
+  // a related to items in a different table
   // while tags can just be anything.
 
   var tag_list = fake.hipster_sentence(5);
   var tags = tag_list.substring(0, tag_list.length - 1).split(" ");
 
   var data = {
-    name: fake.beer_name(),
-    description: desc,
-    price: Math.random() * 19.0,
-    tags: tags,
-    categories: {
-      connect: { id: [1, 2] },
-    },
+    "name": fake.beer_name(),
+    "description": desc,
+    "price": fake.price(),
+    "category_ids":[1,2,3],
+    "user_id": u.id
   };
 
+
+
   var res = graphql(
-    " \
-  mutation { \
-  	product(insert: $data) { \
-  		id \
-  	} \
-  }",
-    { data: data },
-    { user_id: u.id }
+      " \
+    mutation { \
+        products(insert: $data) { \
+            id \
+        } \
+    }",
+      { data: data }
+
   );
 
-  products.push(res.product);
+  products.push(res.products);
 }
 
 // ---- add purchases (joining customers with products)
@@ -186,17 +176,17 @@ for (i = 0; i < purchase_count; i++) {
   };
 
   var res = graphql(
-    " \
-  mutation { \
-  	purchase(insert: $data) { \
-  		id \
-  	} \
-  }",
-    { data: data },
-    { user_id: u.id }
+      " \
+    mutation { \
+        purchases(insert: $data) { \
+            id \
+        } \
+    }",
+      { data: data },
+      { user_id: u.id }
   );
 
-  purchases.push(res.purchase);
+  purchases.push(res.purchases);
 }
 
 // ---- add notifications
@@ -230,17 +220,17 @@ for (i = 0; i < notifications_count; i++) {
   };
 
   var res = graphql(
-    " \
-  mutation { \
-  	notification(insert: $data) { \
-  		id \
-  	} \
-  }",
-    { data: data },
-    { user_id: u.id }
+      " \
+    mutation { \
+        notifications(insert: $data) { \
+            id \
+        } \
+    }",
+      { data: data },
+      { user_id: u.id }
   );
 
-  notifications.push(res.notification);
+  notifications.push(res.notifications);
 }
 
 // ---- add comments
@@ -248,19 +238,13 @@ for (i = 0; i < notifications_count; i++) {
 var comments = [];
 
 for (i = 0; i < comments_count; i++) {
-  var u = users[Math.floor(Math.random() * user_count)];
-  var p = products[Math.floor(Math.random() * product_count)];
+  var userId = Math.floor(Math.random() * user_count) + 1; // no id of 0
+  var productId = Math.floor(Math.random() * product_count) + 1;
 
   var data = {
     body: fake.sentence(10),
-    created_at: "now",
-    updated_at: "now",
-    user: {
-      connect: { id: u.id },
-    },
-    product: {
-      connect: { id: p.id },
-    },
+    product_id: productId,
+    user_id: userId
   };
 
   if (comments.length !== 0) {
@@ -271,18 +255,17 @@ for (i = 0; i < comments_count; i++) {
     };
   }
 
-  console.log(data);
 
   var res = graphql(
-    " \
-  mutation { \
-  	comment(insert: $data) { \
-  		id \
-  	} \
-  }",
-    { data: data },
-    { user_id: u.id }
+      " \
+    mutation { \
+        comments(insert: $data) { \
+            id \
+        } \
+    }",
+      { data: data }
   );
 
-  comments.push(res.comment);
 }
+
+

--- a/examples/webshop/config/seed.js
+++ b/examples/webshop/config/seed.js
@@ -10,7 +10,6 @@ var purchase_count = 100;
 var notifications_count = 100;
 var comments_count = 100;
 
-
 for (i = 0; i < 3; i++) {
   var data = {
     full_name: fake.name(),
@@ -18,18 +17,18 @@ for (i = 0; i < 3; i++) {
     phone: fake.phone(),
     email: "user" + i + "@demo.com",
     password: pwd,
-    password_confirmation: pwd
+    password_confirmation: pwd,
   };
 
   var res = graphql(
-      " \
+    " \
       mutation { \
           users(insert: $data) { \
               id \
           } \
       }",
-      { data: data },
-      { user_id: -1 }
+    { data: data },
+    { user_id: -1 }
   );
 
   users.push(res.users);
@@ -43,23 +42,22 @@ for (i = 0; i < user_count; i++) {
     phone: fake.phone(),
     email: "user_" + i + "_" + fake.email(),
     password: pwd,
-    password_confirmation: pwd
+    password_confirmation: pwd,
   };
 
   var res = graphql(
-      " \
+    " \
       mutation { \
           users(insert: $data) { \
               id \
           } \
       }",
-      { data: data },
-      { user_id: -1 }
+    { data: data },
+    { user_id: -1 }
   );
 
   users.push(res.users);
 }
-
 
 // ---- add customers
 
@@ -78,14 +76,14 @@ for (i = 0; i < customer_count; i++) {
   };
 
   var res = graphql(
-      " \
+    " \
       mutation { \
           customers(insert: $data) { \
               id \
           } \
       }",
-      { data: data },
-      { user_id: u.id }
+    { data: data },
+    { user_id: u.id }
   );
 
   customers.push(res.customer);
@@ -97,25 +95,25 @@ var categories = [
   {
     id: 1,
     name: "Beers",
-    description: "Liquid Bread"
+    description: "Liquid Bread",
   },
   {
     id: 2,
     name: "Alcohol",
-    description: "Bad for you!"
+    description: "Bad for you!",
   },
 ];
 
 // ---- add those sections using bulk insert
 
 var res = graphql(
-    " \
+  " \
   mutation { \
     categories(insert: $categories) { \
       id \
     } \
   }",
-    { categories: categories, user_id: 1 }
+  { categories: categories, user_id: 1 }
 );
 
 // ---- add products
@@ -134,24 +132,21 @@ for (i = 0; i < product_count; i++) {
   var tags = tag_list.substring(0, tag_list.length - 1).split(" ");
 
   var data = {
-    "name": fake.beer_name(),
-    "description": desc,
-    "price": fake.price(),
-    "category_ids":[1,2,3],
-    "user_id": u.id
+    name: fake.beer_name(),
+    description: desc,
+    price: fake.price(),
+    category_ids: [1, 2, 3],
+    user_id: u.id,
   };
 
-
-
   var res = graphql(
-      " \
+    " \
     mutation { \
         products(insert: $data) { \
             id \
         } \
     }",
-      { data: data }
-
+    { data: data }
   );
 
   products.push(res.products);
@@ -176,14 +171,14 @@ for (i = 0; i < purchase_count; i++) {
   };
 
   var res = graphql(
-      " \
+    " \
     mutation { \
         purchases(insert: $data) { \
             id \
         } \
     }",
-      { data: data },
-      { user_id: u.id }
+    { data: data },
+    { user_id: u.id }
   );
 
   purchases.push(res.purchases);
@@ -220,14 +215,14 @@ for (i = 0; i < notifications_count; i++) {
   };
 
   var res = graphql(
-      " \
+    " \
     mutation { \
         notifications(insert: $data) { \
             id \
         } \
     }",
-      { data: data },
-      { user_id: u.id }
+    { data: data },
+    { user_id: u.id }
   );
 
   notifications.push(res.notifications);
@@ -244,7 +239,7 @@ for (i = 0; i < comments_count; i++) {
   var data = {
     body: fake.sentence(10),
     product_id: productId,
-    user_id: userId
+    user_id: userId,
   };
 
   if (comments.length !== 0) {
@@ -255,17 +250,13 @@ for (i = 0; i < comments_count; i++) {
     };
   }
 
-
   var res = graphql(
-      " \
+    " \
     mutation { \
         comments(insert: $data) { \
             id \
         } \
     }",
-      { data: data }
+    { data: data }
   );
-
 }
-
-


### PR DESCRIPTION
This should address new user issues outlined here: https://discord.com/channels/628796009539043348/628796009539043350/811103831499997224

I added `DEFAULT NOW()` in the migrations. This may have impacts elsewhere I am not aware of but seems easier for now. Happy to roll that back and put the `created_at: "now",` back in. 

I think the main issue is the singular to plural. Ex. `user` is now `users`.

Honestly, there may be some other things I missed with nesting and when to use 
```
data: data,
user_id: u.id
```
over just adding the `user_id` into the data. 

Happy to adjust this or, if it is easier, close this PR and you can just update the pieces to your liking. 