### PR TITLE
feat: add subs-creds-in-vars config param

### DIFF
--- a/docs/website/docs/security.md
+++ b/docs/website/docs/security.md
@@ -154,6 +154,30 @@ In addition to the default auth configuration you can create additional named au
 with features like `actions`. For example while your main GraphQL endpoint uses JWT for authentication you may want to use a header value to ensure your actions can only be called by clients having access to a shared secret
 or security header.
 
+### Testing Subscription Authentication
+
+Sending HTTP headers is not allowed over WebSocket, so it has to be done during the `connection_init` message over WebSocket sending the headers inside the JSON payload of the message.
+
+If you want to test the Authentication of the subscriptions with an standard client that is not able to pass the headers over WebSocket, you could set the `subs_creds_in_vars` param inside the `auth` block of the config file and define the headers inside the variables of the subscription.
+
+```yml
+auth:
+  # Useful for quickly debugging subscriptions WebSocket authorization.
+  # Disable in production
+  subs_creds_in_vars: true
+```
+
+Variables:
+
+```json
+{
+  "example-var": 20,
+  "X-User-ID": "1",
+  "X-User-ID-Provider": "testing-provider",
+  "X-User-Role": "testing-role"
+}
+```
+
 ## Actions
 
 Actions is a very useful feature that is currently work in progress. For now the best use case for actions is to

--- a/internal/serv/internal/auth/auth.go
+++ b/internal/serv/internal/auth/auth.go
@@ -10,10 +10,11 @@ import (
 
 // Auth struct contains authentication related config values used by the GraphJin service
 type Auth struct {
-	Name          string
-	Type          string
-	Cookie        string
-	CredsInHeader bool `mapstructure:"creds_in_header"`
+	Name            string
+	Type            string
+	Cookie          string
+	CredsInHeader   bool `mapstructure:"creds_in_header"`
+	SubsCredsInVars bool `mapstructure:"subs_creds_in_vars"`
 
 	Rails struct {
 		Version       string

--- a/internal/serv/tmpl/dev.yml
+++ b/internal/serv/tmpl/dev.yml
@@ -109,6 +109,10 @@ auth:
   # Disable in production
   creds_in_header: true
 
+  # Useful for quickly debugging subscriptions WebSocket authorization.
+  # Disable in production
+  # subs_creds_in_vars: true
+
   rails:
     # Rails version this is used for reading the
     # various cookies formats.


### PR DESCRIPTION
Add `subs_creds_in_vars` config param inside the `auth` block, so you could test the subscription Authentication defining the headers inside the variables of the subscription.