### PR TITLE
fix: add vars support to role query

### DIFF
--- a/core/args.go
+++ b/core/args.go
@@ -124,48 +124,6 @@ func parseVarVal(v json.RawMessage) interface{} {
 	}
 }
 
-func (gj *GraphJin) roleQueryArgList(c context.Context) (args, error) {
-	ar := args{cindx: -1}
-	params := gj.roleStmtMD.Params()
-	vl := make([]interface{}, len(params))
-
-	for i, p := range params {
-		switch p.Name {
-		case "user_id":
-			if v := c.Value(UserIDKey); v != nil {
-				switch v1 := v.(type) {
-				case string:
-					vl[i] = v1
-				case int:
-					vl[i] = v1
-				case float64:
-					vl[i] = int(v1)
-				default:
-					return ar, fmt.Errorf("user_id must be an integer or a string: %T", v)
-				}
-			} else {
-				return ar, argErr(p)
-			}
-
-		case "user_id_provider":
-			if v := c.Value(UserIDProviderKey); v != nil {
-				vl[i] = v.(string)
-			} else {
-				return ar, argErr(p)
-			}
-
-		case "user_role":
-			if v := c.Value(UserRoleKey); v != nil {
-				vl[i] = v.(string)
-			} else {
-				return ar, argErr(p)
-			}
-		}
-	}
-	ar.values = vl
-	return ar, nil
-}
-
 func argErr(p psql.Param) error {
 	return fmt.Errorf("required variable '%s' of type '%s' must be set", p.Name, p.Type)
 }

--- a/core/core.go
+++ b/core/core.go
@@ -149,7 +149,7 @@ func (gj *GraphJin) initCompilers() error {
 	return nil
 }
 
-func (gj *GraphJin) executeRoleQuery(c context.Context, conn *sql.Conn) (string, error) {
+func (gj *GraphJin) executeRoleQuery(c context.Context, conn *sql.Conn, md psql.Metadata, vars []byte, rc *ReqConfig) (string, error) {
 	var role string
 	var ar args
 	var err error
@@ -165,7 +165,7 @@ func (gj *GraphJin) executeRoleQuery(c context.Context, conn *sql.Conn) (string,
 		return "anon", nil
 	}
 
-	if ar, err = gj.roleQueryArgList(c); err != nil {
+	if ar, err = gj.argList(c, md, vars, rc); err != nil {
 		return "", err
 	}
 
@@ -214,7 +214,7 @@ func (c *scontext) resolveSQL(query string, vars []byte, role string) (qres, err
 		res.role = v.(string)
 
 	} else if c.gj.abacEnabled {
-		res.role, err = c.gj.executeRoleQuery(c, conn)
+		res.role, err = c.gj.executeRoleQuery(c, conn, c.gj.roleStmtMD, vars, c.rc)
 	}
 
 	if err != nil {

--- a/core/subs.go
+++ b/core/subs.go
@@ -99,7 +99,7 @@ func (gj *GraphJin) Subscribe(
 	}
 
 	if role == "user" && gj.abacEnabled {
-		if role, err = gj.executeRoleQuery(c, nil); err != nil {
+		if role, err = gj.executeRoleQuery(c, nil, gj.roleStmtMD, vars, rc); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This fix allows the role query to access the query variables and config dynamic variables.