### PR TITLE
feat: add JWKS JWT auth provider

### DIFF
--- a/docs/website/docs/security.md
+++ b/docs/website/docs/security.md
@@ -95,7 +95,7 @@ auth:
   type: jwt
 
   jwt:
-    # valid providers are auth0, firebase and none
+    # valid providers are auth0, firebase, jwks and none
     provider: auth0
     secret: abc335bfcfdb04e50db5bb0a4d67ab9
     public_key_file: /secrets/public_key.pem
@@ -128,6 +128,33 @@ auth:
 Firebase auth also uses JWT the keys are auto-fetched from Google and used according to their documentation mechanism. The `audience` config value needs to be set to your project id and everything else is taken care for you.
 
 Setting `issuer` is not required for Firebase, it's going to be automatically defined using the `audience` as "https://securetoken.google.com/<audience>".
+
+### JWKS Auth
+
+```yaml
+auth:
+  type: jwt
+
+  jwt:
+    provider: jwks
+    issuer: https://accounts.google.com
+    audience: 1234987819200.apps.googleusercontent.com
+    jwks_url: https://www.googleapis.com/oauth2/v3/certs
+    jwks_min_refresh: 30
+```
+
+The JWKS provider downloads and keeps track of keys which are automatically refreshed from a JWKS endpoint, like "https://YOUR_DOMAIN/.well-known/jwks.json".
+
+Interval between refreshes could be calculated in two ways:
+
+1) You can set an explicit refresh interval in minutes by using `jwks_refresh`. In this mode, it doesn't matter what the HTTP response says in its Cache-Control or Expires headers.
+2) If `jwks_refresh` is not defined, then the time to refresh is automatically calculated based on the key's Cache-Control or Expires headers. You could define an absolute minimum interval before refreshes in minutes with `jwks_min_refresh`. This value is used as a fallback value when tokens are refreshed, if unspecified, the minimum refresh interval is 60 minutes.
+
+We can get the JWT token either from the `authorization` header where we expect it to be a `bearer` token or if `cookie` is specified then we look there.
+
+Setting `issuer` is recommended but not required. When specified it's going to be compared against the `iss` claim of the JWT token.
+
+Also `audience` is recommended but not required. When specified it's going to be compared against the `aud` claim of the JWT token. The `aud` claim usually identifies the intended recipient of the token. For Auth0 is the client_id, for other provider could be the domain URL.
 
 ### HTTP Headers
 

--- a/docs/website/docs/security.md
+++ b/docs/website/docs/security.md
@@ -100,6 +100,8 @@ auth:
     secret: abc335bfcfdb04e50db5bb0a4d67ab9
     public_key_file: /secrets/public_key.pem
     public_key_type: ecdsa #rsa
+    issuer: https://my-domain.auth0.com
+    audience: my_client_id
 ```
 
 For JWT tokens we currently support tokens from a provider like Auth0 or if you have a custom solution then we look for the `user_id` in the `subject` claim of of the `id token`. If you pick Auth0 then we derive two variables from the token `user_id` and `user_id_provider` for to use in your filters.
@@ -107,6 +109,10 @@ For JWT tokens we currently support tokens from a provider like Auth0 or if you 
 We can get the JWT token either from the `authorization` header where we expect it to be a `bearer` token or if `cookie` is specified then we look there.
 
 For validation a `secret` or a public key (ecdsa or rsa) is required. When using public keys they have to be in a PEM format file.
+
+Setting `issuer` is recommended but not required. When specified it's going to be compared against the `iss` claim of the JWT token.
+
+Also `audience` is recommended but not required. When specified it's going to be compared against the `aud` claim of the JWT token. The `aud` claim usually identifies the intended recipient of the token. For Auth0 is the client_id, for other provider could be the domain URL.
 
 ### Firebase Auth
 
@@ -120,6 +126,8 @@ auth:
 ```
 
 Firebase auth also uses JWT the keys are auto-fetched from Google and used according to their documentation mechanism. The `audience` config value needs to be set to your project id and everything else is taken care for you.
+
+Setting `issuer` is not required for Firebase, it's going to be automatically defined using the `audience` as "https://securetoken.google.com/<audience>".
 
 ### HTTP Headers
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/gosimple/slug v1.9.0
 	github.com/jackc/pgproto3/v2 v2.0.4 // indirect
 	github.com/jackc/pgx/v4 v4.8.1
+	github.com/lestrrat-go/jwx v1.1.3
 	github.com/mitchellh/mapstructure v1.4.0
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/openzipkin/zipkin-go v0.2.4
@@ -49,7 +50,7 @@ require (
 	go.opencensus.io v0.22.5
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
-	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
+	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/perf v0.0.0-20201207232921-bdcc6220ee90
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,10 @@ github.com/daixiang0/gci v0.2.8/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKgg
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 h1:sgNeV1VRMDzs6rzyPpxyM0jp317hnwiq58Filgag2xw=
+github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0/go.mod h1:J70FGZSbzsjecRTiTzER+3f1KZLNaXkuv+yeFTKoxM8=
 github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
@@ -436,6 +440,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/goccy/go-json v0.4.7 h1:xGUjaNfhpqhKAV2LoyNXihFLZ8ABSST8B+W+duHqkPI=
+github.com/goccy/go-json v0.4.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gofrs/flock v0.8.0 h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=
 github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
@@ -786,6 +792,20 @@ github.com/kunwardeep/paralleltest v1.0.2/go.mod h1:ZPqNm1fVHPllh5LPVujzbVz1JN2G
 github.com/kyoh86/exportloopref v0.1.8 h1:5Ry/at+eFdkX9Vsdw3qU4YkvGtzuVfzT4X7S77LoN/M=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/lestrrat-go/backoff/v2 v2.0.7 h1:i2SeK33aOFJlUNJZzf2IpXRBvqBBnaGXfY5Xaop/GsE=
+github.com/lestrrat-go/backoff/v2 v2.0.7/go.mod h1:rHP/q/r9aT27n24JQLa7JhSQZCKBBOiM/uP402WwN8Y=
+github.com/lestrrat-go/codegen v1.0.0/go.mod h1:JhJw6OQAuPEfVKUCLItpaVLumDGWQznd1VaXrBk9TdM=
+github.com/lestrrat-go/httpcc v1.0.0 h1:FszVC6cKfDvBKcJv646+lkh4GydQg2Z29scgUfkOpYc=
+github.com/lestrrat-go/httpcc v1.0.0/go.mod h1:tGS/u00Vh5N6FHNkExqGGNId8e0Big+++0Gf8MBnAvE=
+github.com/lestrrat-go/iter v1.0.0 h1:QD+hHQPDSHC4rCJkZYY/yXChYr/vjfBopKekTc+7l4Q=
+github.com/lestrrat-go/iter v1.0.0/go.mod h1:zIdgO1mRKhn8l9vrZJZz9TUMMFbQbLeTsbqPDrJ/OJc=
+github.com/lestrrat-go/jwx v1.1.3 h1:a3yw3TjcsIUAmZefqTJh8S522MTSkRm2k90pWTJTa0E=
+github.com/lestrrat-go/jwx v1.1.3/go.mod h1:Q+ncWBOZmzkVfTN0SWsKuvjkXeJau0BTTNTifDFvfr0=
+github.com/lestrrat-go/option v0.0.0-20210103042652-6f1ecfceda35/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
+github.com/lestrrat-go/option v1.0.0 h1:WqAWL8kh8VcSoD6xjSH34/1m8yxluXQbDeKNfvFeEO4=
+github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
+github.com/lestrrat-go/pdebug/v3 v3.0.1 h1:3G5sX/aw/TbMTtVc9U7IHBWRZtMvwvBziF1e4HoQtv8=
+github.com/lestrrat-go/pdebug/v3 v3.0.1/go.mod h1:za+m+Ve24yCxTEhR59N7UlnJomWwCiIqbJRmKeiADU4=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1259,8 +1279,14 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 h1:sYNJzB4J8toYPQTM6pAkcmBRgw9SnQKP9oXCHfgy604=
 golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+<<<<<<< HEAD
+=======
+golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 h1:3wPMTskHO3+O6jqTEXyFcsnuxMQOqYSaHsDxcbUXpqA=
+golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+>>>>>>> feat: add  JWKS auth provider
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1292,8 +1318,9 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
+golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1549,6 +1576,7 @@ golang.org/x/tools v0.0.0-20201230224404-63754364767c/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210102185154-773b96fafca2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105210202-9ed45478a130/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1280,13 +1280,8 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-<<<<<<< HEAD
-=======
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 h1:3wPMTskHO3+O6jqTEXyFcsnuxMQOqYSaHsDxcbUXpqA=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
->>>>>>> feat: add  JWKS auth provider
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/internal/serv/api.go
+++ b/internal/serv/api.go
@@ -102,37 +102,37 @@ type Serv struct {
 	} `mapstructure:"rate_limiter"`
 }
 
-// Auth struct contains authentication related config values used by the GraphJin service
-type Auth struct {
-	Name          string
-	Type          string
-	Cookie        string
-	CredsInHeader bool `mapstructure:"creds_in_header"`
-	Rails         struct {
-		Version       string
-		SecretKeyBase string `mapstructure:"secret_key_base"`
-		URL           string
-		Password      string
-		MaxIdle       int `mapstructure:"max_idle"`
-		MaxActive     int `mapstructure:"max_active"`
-		Salt          string
-		SignSalt      string `mapstructure:"sign_salt"`
-		AuthSalt      string `mapstructure:"auth_salt"`
-	}
+// // Auth struct contains authentication related config values used by the GraphJin service
+// type Auth struct {
+// 	Name          string
+// 	Type          string
+// 	Cookie        string
+// 	CredsInHeader bool `mapstructure:"creds_in_header"`
+// 	Rails         struct {
+// 		Version       string
+// 		SecretKeyBase string `mapstructure:"secret_key_base"`
+// 		URL           string
+// 		Password      string
+// 		MaxIdle       int `mapstructure:"max_idle"`
+// 		MaxActive     int `mapstructure:"max_active"`
+// 		Salt          string
+// 		SignSalt      string `mapstructure:"sign_salt"`
+// 		AuthSalt      string `mapstructure:"auth_salt"`
+// 	}
 
-	JWT struct {
-		Provider   string
-		Secret     string
-		PubKeyFile string `mapstructure:"public_key_file"`
-		PubKeyType string `mapstructure:"public_key_type"`
-	}
+// 	JWT struct {
+// 		Provider   string
+// 		Secret     string
+// 		PubKeyFile string `mapstructure:"public_key_file"`
+// 		PubKeyType string `mapstructure:"public_key_type"`
+// 	}
 
-	Header struct {
-		Name   string
-		Value  string
-		Exists bool
-	}
-}
+// 	Header struct {
+// 		Name   string
+// 		Value  string
+// 		Exists bool
+// 	}
+// }
 
 // Action struct contains config values for a GraphJin service action
 type Action struct {

--- a/internal/serv/internal/auth/auth.go
+++ b/internal/serv/internal/auth/auth.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"github.com/dosco/graphjin/core"
+
+	"github.com/dosco/graphjin/internal/serv/internal/auth/provider"
 )
 
 // Auth struct contains authentication related config values used by the GraphJin service
@@ -28,13 +30,7 @@ type Auth struct {
 		AuthSalt      string `mapstructure:"auth_salt"`
 	}
 
-	JWT struct {
-		Provider   string
-		Secret     string
-		PubKeyFile string `mapstructure:"public_key_file"`
-		PubKeyType string `mapstructure:"public_key_type"`
-		Audience   string `mapstructure:"audience"`
-	}
+	JWT provider.JWTConfig
 
 	Header struct {
 		Name   string

--- a/internal/serv/internal/auth/jwt.go
+++ b/internal/serv/internal/auth/jwt.go
@@ -1,78 +1,24 @@
 package auth
 
 import (
-	"context"
-	"encoding/json"
-	"io/ioutil"
 	"net/http"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/dosco/graphjin/core"
+
+	"github.com/dosco/graphjin/internal/serv/internal/auth/provider"
 )
 
 const (
-	authHeader               = "Authorization"
-	jwtAuth0             int = iota + 1
-	jwtFirebase          int = iota + 2
-	firebasePKEndpoint       = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
-	firebaseIssuerPrefix     = "https://securetoken.google.com/"
+	authHeader = "Authorization"
 )
 
-type firebasePKCache struct {
-	PublicKeys map[string]string
-	Expiration time.Time
-	lock       sync.RWMutex
-}
-
-var firebasePublicKeys = firebasePKCache{
-	lock: sync.RWMutex{},
-}
-
 func JwtHandler(ac *Auth, next http.Handler) (http.HandlerFunc, error) {
-	var key interface{}
-	var jwtProvider int
+	jwtProvider, err := provider.NewProvider(ac.JWT)
+	if err != nil {
+		return nil, err
+	}
 
 	cookie := ac.Cookie
-
-	if ac.JWT.Provider == "auth0" {
-		jwtProvider = jwtAuth0
-	} else if ac.JWT.Provider == "firebase" {
-		jwtProvider = jwtFirebase
-	}
-
-	secret := ac.JWT.Secret
-	publicKeyFile := ac.JWT.PubKeyFile
-
-	switch {
-	case secret != "":
-		key = []byte(secret)
-
-	case publicKeyFile != "":
-		kd, err := ioutil.ReadFile(publicKeyFile)
-		if err != nil {
-			return nil, err
-		}
-
-		switch ac.JWT.PubKeyType {
-		case "ecdsa":
-			key, err = jwt.ParseECPublicKeyFromPEM(kd)
-
-		case "rsa":
-			key, err = jwt.ParseRSAPublicKeyFromPEM(kd)
-
-		default:
-			key, err = jwt.ParseECPublicKeyFromPEM(kd)
-
-		}
-
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
@@ -94,41 +40,32 @@ func JwtHandler(ac *Auth, next http.Handler) (http.HandlerFunc, error) {
 			tok = ah[7:]
 		}
 
-		var keyFunc jwt.Keyfunc
-		if jwtProvider == jwtFirebase {
-			keyFunc = firebaseKeyFunction
-		} else {
-			keyFunc = func(token *jwt.Token) (interface{}, error) {
-				return key, nil
-			}
-		}
+		keyFunc := jwtProvider.KeyFunc()
 
-		token, err := jwt.ParseWithClaims(tok, &jwt.StandardClaims{}, keyFunc)
+		token, err := jwt.ParseWithClaims(tok, jwt.MapClaims{}, keyFunc) //jwt.MapClaims is already passed by reference
 
 		if err != nil {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		if claims, ok := token.Claims.(*jwt.StandardClaims); ok {
+		if claims, ok := token.Claims.(jwt.MapClaims); ok {
 			ctx := r.Context()
 
-			if ac.JWT.Audience != "" && claims.Audience != ac.JWT.Audience {
+			if !jwtProvider.VerifyAudience(claims) {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			if jwtProvider == jwtAuth0 {
-				sub := strings.Split(claims.Subject, "|")
-				if len(sub) != 2 {
-					ctx = context.WithValue(ctx, core.UserIDProviderKey, sub[0])
-					ctx = context.WithValue(ctx, core.UserIDKey, sub[1])
-				}
-			} else if jwtProvider == jwtFirebase &&
-				claims.Issuer == firebaseIssuerPrefix+ac.JWT.Audience {
-				ctx = context.WithValue(ctx, core.UserIDKey, claims.Subject)
-			} else {
-				ctx = context.WithValue(ctx, core.UserIDKey, claims.Subject)
+			if !jwtProvider.VerifyIssuer(claims) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			ctx, err = jwtProvider.SetContextValues(ctx, claims)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -137,100 +74,4 @@ func JwtHandler(ac *Auth, next http.Handler) (http.HandlerFunc, error) {
 
 		next.ServeHTTP(w, r)
 	}, nil
-}
-
-type firebaseKeyError struct {
-	Err     error
-	Message string
-}
-
-func (e *firebaseKeyError) Error() string {
-	return e.Message + " " + e.Err.Error()
-}
-
-func firebaseKeyFunction(token *jwt.Token) (interface{}, error) {
-	kid, ok := token.Header["kid"]
-
-	if !ok {
-		return nil, &firebaseKeyError{
-			Message: "Error 'kid' header not found in token",
-		}
-	}
-
-	firebasePublicKeys.lock.RLock()
-	pastExpiration := firebasePublicKeys.Expiration.Before(time.Now())
-	firebasePublicKeys.lock.RUnlock()
-	if pastExpiration {
-		resp, err := http.Get(firebasePKEndpoint)
-
-		if err != nil {
-			return nil, &firebaseKeyError{
-				Message: "Error connecting to firebase certificate server",
-				Err:     err,
-			}
-		}
-
-		defer resp.Body.Close()
-
-		data, err := ioutil.ReadAll(resp.Body)
-
-		if err != nil {
-			return nil, &firebaseKeyError{
-				Message: "Error reading firebase certificate server response",
-				Err:     err,
-			}
-		}
-
-		cachePolicy := resp.Header.Get("cache-control")
-		ageIndex := strings.Index(cachePolicy, "max-age=")
-
-		if ageIndex < 0 {
-			return nil, &firebaseKeyError{
-				Message: "Error parsing cache-control header: 'max-age=' not found",
-			}
-		}
-
-		ageToEnd := cachePolicy[ageIndex+8:]
-		endIndex := strings.Index(ageToEnd, ",")
-		if endIndex < 0 {
-			endIndex = len(ageToEnd) - 1
-		}
-		ageString := ageToEnd[:endIndex]
-
-		age, err := strconv.ParseInt(ageString, 10, 64)
-
-		if err != nil {
-			return nil, &firebaseKeyError{
-				Message: "Error parsing max-age cache policy",
-				Err:     err,
-			}
-		}
-
-		expiration := time.Now().Add(time.Duration(time.Duration(age) * time.Second))
-
-		firebasePublicKeys.lock.Lock()
-		err = json.Unmarshal(data, &firebasePublicKeys.PublicKeys)
-
-		if err != nil {
-			firebasePublicKeys.lock.Unlock()
-			return nil, &firebaseKeyError{
-				Message: "Error unmarshalling firebase public key json",
-				Err:     err,
-			}
-		}
-
-		firebasePublicKeys.Expiration = expiration
-		firebasePublicKeys.lock.Unlock()
-	}
-
-	firebasePublicKeys.lock.RLock()
-	defer firebasePublicKeys.lock.RUnlock()
-	if key, found := firebasePublicKeys.PublicKeys[kid.(string)]; found {
-		k, err := jwt.ParseRSAPublicKeyFromPEM([]byte(key))
-		return k, err
-	}
-
-	return nil, &firebaseKeyError{
-		Message: "Error no matching public key for kid supplied in jwt",
-	}
 }

--- a/internal/serv/internal/auth/provider/auth0.go
+++ b/internal/serv/internal/auth/provider/auth0.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dosco/graphjin/core"
+)
+
+type Auth0Provider struct {
+	key    interface{}
+	aud    string
+	issuer string
+}
+
+func NewAuth0Provider(config JWTConfig) (*Auth0Provider, error) {
+	key, err := getKey(config)
+	if err != nil {
+		return nil, err
+	}
+	return &Auth0Provider{
+		key:    key,
+		aud:    config.Audience,
+		issuer: config.Issuer,
+	}, nil
+}
+
+func (p *Auth0Provider) KeyFunc() jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		return p.key, nil
+	}
+}
+
+func (p *Auth0Provider) VerifyAudience(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyAudience(p.aud, p.aud != "")
+}
+
+func (p *Auth0Provider) VerifyIssuer(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyIssuer(p.issuer, p.issuer != "")
+}
+
+func (p *Auth0Provider) SetContextValues(ctx context.Context, claims jwt.MapClaims) (context.Context, error) {
+	if claims == nil {
+		return ctx, errors.New("undefined claims")
+	}
+	sub, found := claims["sub"].(string)
+	if !found {
+		return ctx, errors.New("subject claim not found")
+	}
+	sp := strings.Split(sub, "|")
+	if len(sub) == 2 {
+		ctx = context.WithValue(ctx, core.UserIDProviderKey, sp[0])
+		ctx = context.WithValue(ctx, core.UserIDKey, sp[1])
+	} else {
+		ctx = context.WithValue(ctx, core.UserIDKey, sub)
+	}
+	return ctx, nil
+}

--- a/internal/serv/internal/auth/provider/firebase.go
+++ b/internal/serv/internal/auth/provider/firebase.go
@@ -1,0 +1,173 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dosco/graphjin/core"
+)
+
+const (
+	firebasePKEndpoint   = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
+	firebaseIssuerPrefix = "https://securetoken.google.com/"
+)
+
+type firebasePKCache struct {
+	PublicKeys map[string]string
+	Expiration time.Time
+	lock       sync.RWMutex
+}
+
+var firebasePublicKeys = firebasePKCache{
+	lock: sync.RWMutex{},
+}
+
+type FirebaseProvider struct {
+	aud    string
+	issuer string
+}
+
+func NewFirebaseProvider(config JWTConfig) (*FirebaseProvider, error) {
+	issuer := config.Issuer
+	if issuer == "" {
+		issuer = firebaseIssuerPrefix + config.Audience
+	}
+	return &FirebaseProvider{
+		aud:    config.Audience,
+		issuer: issuer,
+	}, nil
+}
+
+func (p *FirebaseProvider) KeyFunc() jwt.Keyfunc {
+	return firebaseKeyFunction
+}
+
+func (p *FirebaseProvider) VerifyAudience(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyAudience(p.aud, p.aud != "")
+}
+
+func (p *FirebaseProvider) VerifyIssuer(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyIssuer(p.issuer, p.issuer != "")
+}
+
+func (p *FirebaseProvider) SetContextValues(ctx context.Context, claims jwt.MapClaims) (context.Context, error) {
+	if claims == nil {
+		return ctx, errors.New("undefined claims")
+	}
+	sub, found := claims["sub"].(string)
+	if !found {
+		return ctx, errors.New("subject claim not found")
+	}
+	ctx = context.WithValue(ctx, core.UserIDKey, sub)
+	return ctx, nil
+}
+
+type firebaseKeyError struct {
+	Err     error
+	Message string
+}
+
+func (e *firebaseKeyError) Error() string {
+	return e.Message + " " + e.Err.Error()
+}
+
+func firebaseKeyFunction(token *jwt.Token) (interface{}, error) {
+	kid, ok := token.Header["kid"]
+
+	if !ok {
+		return nil, &firebaseKeyError{
+			Message: "Error 'kid' header not found in token",
+		}
+	}
+
+	firebasePublicKeys.lock.RLock()
+	pastExpiration := firebasePublicKeys.Expiration.Before(time.Now())
+	firebasePublicKeys.lock.RUnlock()
+	if pastExpiration {
+		resp, err := http.Get(firebasePKEndpoint)
+
+		if err != nil {
+			return nil, &firebaseKeyError{
+				Message: "Error connecting to firebase certificate server",
+				Err:     err,
+			}
+		}
+
+		defer resp.Body.Close()
+
+		data, err := ioutil.ReadAll(resp.Body)
+
+		if err != nil {
+			return nil, &firebaseKeyError{
+				Message: "Error reading firebase certificate server response",
+				Err:     err,
+			}
+		}
+
+		cachePolicy := resp.Header.Get("cache-control")
+		ageIndex := strings.Index(cachePolicy, "max-age=")
+
+		if ageIndex < 0 {
+			return nil, &firebaseKeyError{
+				Message: "Error parsing cache-control header: 'max-age=' not found",
+			}
+		}
+
+		ageToEnd := cachePolicy[ageIndex+8:]
+		endIndex := strings.Index(ageToEnd, ",")
+		if endIndex < 0 {
+			endIndex = len(ageToEnd) - 1
+		}
+		ageString := ageToEnd[:endIndex]
+
+		age, err := strconv.ParseInt(ageString, 10, 64)
+
+		if err != nil {
+			return nil, &firebaseKeyError{
+				Message: "Error parsing max-age cache policy",
+				Err:     err,
+			}
+		}
+
+		expiration := time.Now().Add(time.Duration(time.Duration(age) * time.Second))
+
+		firebasePublicKeys.lock.Lock()
+		err = json.Unmarshal(data, &firebasePublicKeys.PublicKeys)
+
+		if err != nil {
+			firebasePublicKeys.lock.Unlock()
+			return nil, &firebaseKeyError{
+				Message: "Error unmarshalling firebase public key json",
+				Err:     err,
+			}
+		}
+
+		firebasePublicKeys.Expiration = expiration
+		firebasePublicKeys.lock.Unlock()
+	}
+
+	firebasePublicKeys.lock.RLock()
+	defer firebasePublicKeys.lock.RUnlock()
+	if key, found := firebasePublicKeys.PublicKeys[kid.(string)]; found {
+		k, err := jwt.ParseRSAPublicKeyFromPEM([]byte(key))
+		return k, err
+	}
+
+	return nil, &firebaseKeyError{
+		Message: "Error no matching public key for kid supplied in jwt",
+	}
+}

--- a/internal/serv/internal/auth/provider/generic.go
+++ b/internal/serv/internal/auth/provider/generic.go
@@ -1,0 +1,59 @@
+package provider
+
+import (
+	"context"
+	"errors"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dosco/graphjin/core"
+)
+
+type GenericProvider struct {
+	key    interface{}
+	aud    string
+	issuer string
+}
+
+func NewGenericProvider(config JWTConfig) (*GenericProvider, error) {
+	key, err := getKey(config)
+	if err != nil {
+		return nil, err
+	}
+	return &GenericProvider{
+		key:    key,
+		aud:    config.Audience,
+		issuer: config.Issuer,
+	}, nil
+}
+
+func (p *GenericProvider) KeyFunc() jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		return p.key, nil
+	}
+}
+
+func (p *GenericProvider) VerifyAudience(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyAudience(p.aud, p.aud != "")
+}
+
+func (p *GenericProvider) VerifyIssuer(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyIssuer(p.issuer, p.issuer != "")
+}
+
+func (p *GenericProvider) SetContextValues(ctx context.Context, claims jwt.MapClaims) (context.Context, error) {
+	if claims == nil {
+		return ctx, errors.New("undefined claims")
+	}
+	sub, found := claims["sub"].(string)
+	if !found {
+		return ctx, errors.New("subject claim not found")
+	}
+	ctx = context.WithValue(ctx, core.UserIDKey, sub)
+	return ctx, nil
+}

--- a/internal/serv/internal/auth/provider/jwks.go
+++ b/internal/serv/internal/auth/provider/jwks.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/lestrrat-go/jwx/jwk"
+
+	"github.com/dosco/graphjin/core"
+)
+
+type keychainCache struct {
+	jwksURL  string
+	keyCache *jwk.AutoRefresh //local in-memory cache to store keys
+}
+
+func newKeychainCache(jwksURL string, refreshInterval, minRefreshInterval int) *keychainCache {
+	ar := jwk.NewAutoRefresh(context.Background())
+	if refreshInterval > 0 {
+		ar.Configure(jwksURL, jwk.WithRefreshInterval(time.Duration(refreshInterval)*time.Minute))
+	} else if minRefreshInterval > 0 {
+		ar.Configure(jwksURL, jwk.WithMinRefreshInterval(time.Duration(minRefreshInterval)*time.Minute))
+	} else {
+		ar.Configure(jwksURL)
+	}
+	return &keychainCache{
+		jwksURL:  jwksURL,
+		keyCache: ar,
+	}
+}
+
+func (k *keychainCache) getKey(kid string) (interface{}, error) {
+	set, err := k.keyCache.Fetch(context.TODO(), k.jwksURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch JWKS: %w", err)
+	}
+	if key, found := set.LookupKeyID(kid); found {
+		var rawkey interface{}
+		err := key.Raw(&rawkey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create key: %w", err)
+		}
+		return rawkey, nil
+	}
+	return nil, errors.New("key not found")
+}
+
+type JWKSProvider struct {
+	aud    string
+	issuer string
+	cache  *keychainCache
+}
+
+func NewJWKSProvider(config JWTConfig) (*JWKSProvider, error) {
+	if config.JWKSURL == "" {
+		return nil, errors.New("undefined JWKSURL")
+	}
+	return &JWKSProvider{
+		aud:    config.Audience,
+		issuer: config.Issuer,
+		cache:  newKeychainCache(config.JWKSURL, config.JWKSRefresh, config.JWKSMinRefresh),
+	}, nil
+}
+
+func (p *JWKSProvider) KeyFunc() jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		if token == nil {
+			return nil, errors.New("null token")
+		}
+		if token.Header == nil {
+			return nil, errors.New("null token header")
+		}
+		kid, found := token.Header["kid"].(string)
+		if !found {
+			return nil, errors.New("kid not found")
+		}
+		key, err := p.cache.getKey(kid)
+		if err != nil {
+			return nil, err
+		}
+		if key == nil {
+			return nil, errors.New("key not found")
+		}
+		return key, nil
+	}
+}
+
+func (p *JWKSProvider) VerifyAudience(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyAudience(p.aud, p.aud != "")
+}
+
+func (p *JWKSProvider) VerifyIssuer(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.VerifyIssuer(p.issuer, p.issuer != "")
+}
+
+func (p *JWKSProvider) SetContextValues(ctx context.Context, claims jwt.MapClaims) (context.Context, error) {
+	if claims == nil {
+		return ctx, errors.New("undefined claims")
+	}
+	sub, found := claims["sub"].(string)
+	if !found {
+		return ctx, errors.New("subject claim not found")
+	}
+	ctx = context.WithValue(ctx, core.UserIDKey, sub)
+	return ctx, nil
+}

--- a/internal/serv/internal/auth/provider/provider.go
+++ b/internal/serv/internal/auth/provider/provider.go
@@ -11,12 +11,15 @@ import (
 // JWTConfig struct contains JWT authentication related config values used by
 // the GraphJin service
 type JWTConfig struct {
-	Provider   string
-	Secret     string
-	PubKeyFile string `mapstructure:"public_key_file"`
-	PubKeyType string `mapstructure:"public_key_type"`
-	Audience   string `mapstructure:"audience"`
-	Issuer     string `mapstructure:"issuer"` //like "http://my-domain.auth0.com"
+	Provider       string
+	Secret         string
+	PubKeyFile     string `mapstructure:"public_key_file"`
+	PubKeyType     string `mapstructure:"public_key_type"`
+	Audience       string `mapstructure:"audience"`
+	Issuer         string `mapstructure:"issuer"`           //like "http://my-domain.auth0.com"
+	JWKSURL        string `mapstructure:"jwks_url"`         //URL of the JWKS endpoint, like "https://YOUR_DOMAIN/.well-known/jwks.json"
+	JWKSRefresh    int    `mapstructure:"jwks_refresh"`     //static minutes interval between refreshes, overriding the adaptive token refreshing
+	JWKSMinRefresh int    `mapstructure:"jwks_min_refresh"` //minutes fallback value when tokens are refreshed, default to 60 minutes
 }
 
 // JWTProvider is the interface to define providers for doing JWT
@@ -34,6 +37,8 @@ func NewProvider(config JWTConfig) (JWTProvider, error) {
 		return NewAuth0Provider(config)
 	case "firebase":
 		return NewFirebaseProvider(config)
+	case "jwks":
+		return NewJWKSProvider(config)
 	default:
 		return NewGenericProvider(config)
 	}

--- a/internal/serv/internal/auth/provider/provider.go
+++ b/internal/serv/internal/auth/provider/provider.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+// JWTConfig struct contains JWT authentication related config values used by
+// the GraphJin service
+type JWTConfig struct {
+	Provider   string
+	Secret     string
+	PubKeyFile string `mapstructure:"public_key_file"`
+	PubKeyType string `mapstructure:"public_key_type"`
+	Audience   string `mapstructure:"audience"`
+	Issuer     string `mapstructure:"issuer"` //like "http://my-domain.auth0.com"
+}
+
+// JWTProvider is the interface to define providers for doing JWT
+// authentication.
+type JWTProvider interface {
+	KeyFunc() jwt.Keyfunc
+	VerifyAudience(jwt.MapClaims) bool
+	VerifyIssuer(jwt.MapClaims) bool
+	SetContextValues(context.Context, jwt.MapClaims) (context.Context, error)
+}
+
+func NewProvider(config JWTConfig) (JWTProvider, error) {
+	switch config.Provider {
+	case "auth0":
+		return NewAuth0Provider(config)
+	case "firebase":
+		return NewFirebaseProvider(config)
+	default:
+		return NewGenericProvider(config)
+	}
+}
+
+func getKey(config JWTConfig) (interface{}, error) {
+	var key interface{}
+	secret := config.Secret
+	publicKeyFile := config.PubKeyFile
+	switch {
+	case secret != "":
+		key = []byte(secret)
+	case publicKeyFile != "":
+		kd, err := ioutil.ReadFile(publicKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		switch config.PubKeyType {
+		case "ecdsa":
+			key, err = jwt.ParseECPublicKeyFromPEM(kd)
+		case "rsa":
+			key, err = jwt.ParseRSAPublicKeyFromPEM(kd)
+		default:
+			key, err = jwt.ParseECPublicKeyFromPEM(kd)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if key == nil {
+		return nil, errors.New("undefined key")
+	}
+	return key, nil
+}


### PR DESCRIPTION
This pull refactors the jwt auth provider to use an interface and defines a new JWT provider `jwks` that retrieves the keys from the well known jwks url of an external auth service. It keeps the keys auto refreshed supporting key rotation. 