### PR TITLE
feat: CORS add support to allowed headers

### DIFF
--- a/examples/webshop/config/dev.yml
+++ b/examples/webshop/config/dev.yml
@@ -46,6 +46,13 @@ secret_key: supercalifajalistics
 # characters (i.e.: http://*.domain.com).
 cors_allowed_origins: ["*"]
 
+# CORS: A list of headers the client is allowed to use with cross-domain
+# requests. If the special "*" value is present in the list, all headers will be
+# allowed. Default value is ["Origin", "Accept", "Content-Type",
+# "X-Requested-With", "Authorization"]. Even if the list is empty, the "Origin"
+# is always appended to the list.
+cors_allowed_headers: []
+
 # Debug Cross Origin Resource Sharing requests
 cors_debug: false
 

--- a/examples/webshop/config/prod.yml
+++ b/examples/webshop/config/prod.yml
@@ -49,6 +49,13 @@ reload_on_config_change: false
 # characters (i.e.: http://*.domain.com).
 # cors_allowed_origins: ["*"]
 
+# CORS: A list of headers the client is allowed to use with cross-domain
+# requests. If the special "*" value is present in the list, all headers will be
+# allowed. Default value is ["Origin", "Accept", "Content-Type",
+# "X-Requested-With", "Authorization"]. Even if the list is empty, the "Origin"
+# is always appended to the list.
+# cors_allowed_headers: []
+
 # Debug Cross Origin Resource Sharing requests
 # cors_debug: false
 

--- a/internal/serv/api.go
+++ b/internal/serv/api.go
@@ -47,6 +47,7 @@ type Serv struct {
 	SeedFile       string   `mapstructure:"seed_file"`
 	MigrationsPath string   `mapstructure:"migrations_path"`
 	AllowedOrigins []string `mapstructure:"cors_allowed_origins"`
+	AllowedHeaders []string `mapstructure:"cors_allowed_headers"`
 	DebugCORS      bool     `mapstructure:"cors_debug"`
 	APIPath        string   `mapstructure:"api_path"`
 	CacheControl   string   `mapstructure:"cache_control"`

--- a/internal/serv/http.go
+++ b/internal/serv/http.go
@@ -43,8 +43,13 @@ func apiV1Handler(sc *ServConfig) http.Handler {
 	}
 
 	if len(sc.conf.AllowedOrigins) != 0 {
+		allowedHeaders := []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "Authorization"}
+		if len(sc.conf.AllowedHeaders) != 0 {
+			allowedHeaders = sc.conf.AllowedHeaders
+		}
 		c := cors.New(cors.Options{
 			AllowedOrigins:   sc.conf.AllowedOrigins,
+			AllowedHeaders:   allowedHeaders,
 			AllowCredentials: true,
 			Debug:            sc.conf.DebugCORS,
 		})

--- a/internal/serv/tmpl/dev.yml
+++ b/internal/serv/tmpl/dev.yml
@@ -46,6 +46,13 @@ secret_key: supercalifajalistics
 # characters (i.e.: http://*.domain.com).
 cors_allowed_origins: ["*"]
 
+# CORS: A list of headers the client is allowed to use with cross-domain
+# requests. If the special "*" value is present in the list, all headers will be
+# allowed. Default value is ["Origin", "Accept", "Content-Type",
+# "X-Requested-With", "Authorization"]. Even if the list is empty, the "Origin"
+# is always appended to the list.
+cors_allowed_headers: []
+
 # Debug Cross Origin Resource Sharing requests
 cors_debug: false
 

--- a/internal/serv/tmpl/prod.yml
+++ b/internal/serv/tmpl/prod.yml
@@ -49,6 +49,13 @@ reload_on_config_change: false
 # characters (i.e.: http://*.domain.com).
 # cors_allowed_origins: ["*"]
 
+# CORS: A list of headers the client is allowed to use with cross-domain
+# requests. If the special "*" value is present in the list, all headers will be
+# allowed. Default value is ["Origin", "Accept", "Content-Type",
+# "X-Requested-With", "Authorization"]. Even if the list is empty, the "Origin"
+# is always appended to the list.
+# cors_allowed_headers: []
+
 # Debug Cross Origin Resource Sharing requests
 # cors_debug: false
 


### PR DESCRIPTION
Add support to define the allowed headers for CORS, usually is not necessary but sometimes you need an specific header. Even for developing with CORS you need it to pass the `X-User-ID` header.