### PR TITLE
docs: fix Kubernetes example

### DIFF
--- a/docs/website/docs/deploy.md
+++ b/docs/website/docs/deploy.md
@@ -156,4 +156,34 @@ spec:
           image: docker.io/dosco/graphjin:latest
           ports:
             - containerPort: 8080
+          env:
+            - name: GO_ENV
+              value: dev
+          volumeMounts:
+            - name: config
+              mountPath: /config/dev.yaml
+              subPath: dev.yaml
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: graphjin-config
+            items:
+            - key: dev.yaml
+              path: dev.yaml
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: graphjin-config
+stringData:
+  dev.yaml: |
+    database:
+      type: postgres
+      host: db
+      port: 5432
+      dbname: app_development
+      user: postgres
+      password: postgres
 ```


### PR DESCRIPTION
After deploying according to the documentation, the container goes into CrashLoopBackOff.

```
$ kubectl logs graphjin-56949dcb7-qggjq
FATAL   failed to read config: Config File "prod" Not Found in "[/config]"
```

By configuring it as shown in this PR, the container has been started.



P.S. Thank you for this product. I was looking for "Hasura written in Go".