### PR TITLE
fix: cacheControl on null qcode

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -281,7 +281,9 @@ func (gj *GraphJin) GraphQL(
 
 	if qres.qc != nil {
 		res.sql = qres.qc.st.sql
-		res.cacheControl = qres.qc.st.qc.Cache.Header
+		if qres.qc.st.qc != nil {
+			res.cacheControl = qres.qc.st.qc.Cache.Header
+		}
 	}
 
 	res.Data = json.RawMessage(qres.data)


### PR DESCRIPTION
check if the qcode is null prior to set the cacheControl.

when running in production mode, if for example you send a query with an invalid JWT, or query an invalid record, or there is any other issue with the query, qres.qc.st.qc is nil