### PR TITLE
fix: avoid fatal error on seeding

### DIFF
--- a/internal/cmd/tmpl/seed.js
+++ b/internal/cmd/tmpl/seed.js
@@ -2,7 +2,7 @@
 
 let users = [];
 
-for (i = 0; i < 10; i++) {
+for (let i = 0; i < 10; i++) {
   let data = {
     id: i,
     full_name: fake.name(),


### PR DESCRIPTION
Avoid this error : 
FATAL   Failed to execute seed file config/seed.js: ReferenceError: i is not defined at seed.js:5:6(6)
ERROR: 1