### PR TITLE
Avoid "invalid Read on closed Body" extra error message on response.

### DIFF
--- a/serv/internal/auth/magiclink.go
+++ b/serv/internal/auth/magiclink.go
@@ -51,7 +51,6 @@ func MagicLinkHandler(ac *Auth, next http.Handler) (handlerFunc, error) {
 			}
 
 			ctx = context.WithValue(ctx, core.UserIDKey, claims["sub"])
-			next.ServeHTTP(w, r.WithContext(ctx))
 			return ctx, nil
 		}
 


### PR DESCRIPTION
Re-entering serveHTTP state with an r.Body that is already closed will give an "http: invalid Read on closed Body" error,   and the response to the user will end up being invalid JSON by having {"data":..} and {"error":....} at the same time separate new lines.