### PR TITLE
Update jwt_validate.go

### DIFF
--- a/serv/internal/auth/jwt_validate.go
+++ b/serv/internal/auth/jwt_validate.go
@@ -3,13 +3,9 @@
 package auth
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 
 	jwt "github.com/dgrijalva/jwt-go"
-
-	"github.com/dosco/graphjin/serv/internal/auth/provider"
 )
 
 func validateJWT(tok, aud, iss string, keyFunc jwt.Keyfunc) (jwt.MapClaims, error) {


### PR DESCRIPTION
I think these are leftovers?

go build -tags=magiclink .
# github.com/dosco/graphjin/serv/internal/auth
../go/pkg/mod/github.com/dosco/graphjin@v0.16.95/serv/internal/auth/jwt_validate.go:6:2: imported and not used: "context"
../go/pkg/mod/github.com/dosco/graphjin@v0.16.95/serv/internal/auth/jwt_validate.go:8:2: imported and not used: "net/http"
../go/pkg/mod/github.com/dosco/graphjin@v0.16.95/serv/internal/auth/jwt_validate.go:12:2: imported and not used: "github.com/dosco/graphjin/serv/internal/auth/provider"