### PR TITLE
PoC for allowing the admin to require specific operations in the queries via a configuration file.

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	// anonymous mode they have to be added to the 'anon' role config.
 	DefaultBlock bool `mapstructure:"default_block"`
 
-	// Functionality to allow the administrator to require that arguments such as where or Id must be present in all queries.
+	// Functionality to allow the administrator to require at least one of the arguments defined in the configuration file, such as "orderby", "where", "id", etc. exist.
 	RequiredOperations []string
 
 	// Vars is a map of hardcoded variables that can be leveraged in your

--- a/core/config.go
+++ b/core/config.go
@@ -45,6 +45,9 @@ type Config struct {
 	// anonymous mode they have to be added to the 'anon' role config.
 	DefaultBlock bool `mapstructure:"default_block"`
 
+	// Functionality to allow the administrator to require that arguments such as where or Id must be present in all queries.
+	RequiredOperations []string
+
 	// Vars is a map of hardcoded variables that can be leveraged in your
 	// queries (eg. variable admin_id will be $admin_id in the query)
 	Vars map[string]string `mapstructure:"variables"`

--- a/core/core.go
+++ b/core/core.go
@@ -154,6 +154,7 @@ func (gj *GraphJin) initCompilers() error {
 		EnableCamelcase:  gj.conf.EnableCamelcase,
 		EnableInflection: gj.conf.EnableInflection,
 		DBSchema:         gj.schema.DBSchema(),
+		RequiredOperations: gj.conf.RequiredOperations,
 	}
 
 	if gj.allowList != nil && gj.prod {

--- a/core/internal/qcode/config.go
+++ b/core/internal/qcode/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	EnableInflection bool
 	DBSchema         string
 	defTrv           trval
+	RequiredOperations []string
 }
 
 type TConfig struct {

--- a/core/internal/qcode/qcode.go
+++ b/core/internal/qcode/qcode.go
@@ -400,7 +400,7 @@ func (co *Compiler) compileQuery(qc *QCode, op *graph.Operation, role string) er
 
 		co.setLimit(tr, qc, sel)
 
-		if err := co.compileArgs(qc, sel, field.Args, role); err != nil {
+		if err := co.compileArgs(qc, sel, field.Args, role, field.ParentID); err != nil {
 			return err
 		}
 
@@ -876,7 +876,7 @@ func (co *Compiler) compileDirectives(qc *QCode, sel *Select, dirs []graph.Direc
 	return nil
 }
 
-func (co *Compiler) compileArgs(qc *QCode, sel *Select, args []graph.Arg, role string) error {
+func (co *Compiler) compileArgs(qc *QCode, sel *Select, args []graph.Arg, role string, parentId int32) error {
 	var err error
 
 	hasRequiredOps := 0
@@ -929,7 +929,7 @@ func (co *Compiler) compileArgs(qc *QCode, sel *Select, args []graph.Arg, role s
 			return err
 		}
 	}
-	if hasRequiredOps == 0 && len(co.c.RequiredOperations) > 0 {
+	if hasRequiredOps == 0 && len(co.c.RequiredOperations) > 0 && parentId == -1 {
 		return fmt.Errorf("arguments: required operations are not present in the query.")
 	}
 

--- a/core/internal/qcode/qcode.go
+++ b/core/internal/qcode/qcode.go
@@ -879,8 +879,13 @@ func (co *Compiler) compileDirectives(qc *QCode, sel *Select, dirs []graph.Direc
 func (co *Compiler) compileArgs(qc *QCode, sel *Select, args []graph.Arg, role string) error {
 	var err error
 
+	hasRequiredOps := 0
+
 	for i := range args {
 		arg := &args[i]
+		if (doesRequiredArgExist(arg,co.c.RequiredOperations)) {
+			hasRequiredOps++
+		}
 
 		switch arg.Name {
 		case "id":
@@ -923,6 +928,9 @@ func (co *Compiler) compileArgs(qc *QCode, sel *Select, args []graph.Arg, role s
 		if err != nil {
 			return err
 		}
+	}
+	if hasRequiredOps == 0 && len(co.c.RequiredOperations) > 0 {
+		return fmt.Errorf("arguments: required operations are not present in the query.")
 	}
 
 	return nil
@@ -1613,3 +1621,14 @@ func (sel *Select) addArg(arg *graph.Arg) {
 	}
 	sel.Args[arg.Name] = Arg{Val: arg.Val.Val}
 }
+
+func doesRequiredArgExist(arg *graph.Arg, requiredOperations []string) bool{
+	for _,s := range requiredOperations {
+		if s == arg.Name {
+			return true
+		}
+	}
+	return false
+}
+
+


### PR DESCRIPTION
The motivation behind this feature:
- The Allow List only allows prepared statements to be fired in production. This means that multiple clients of a server using graphjin would have to have their queries approved by the administrator in order to use them in production, plus in production, there would not be any freedom for a client to define the shape as he or she wants. We are looking to find a compromise between an administrator which is not allowing for select * queries to be fired, but the end user, where they still have the freedom to define the shape of the output in any environment

The way this feature works:
- We define a configuration which is an array of different types of operations such as "where", "id", orderby", etc that the administrator can require the query to have.
- The current status of this feature requires at least one of these operations to be there in the query fired. 
- The code ensures that the query fired has one of the operations defined in the configuration file. If it does not, it throws an exception saying that the query is missing a required operation. 
- This only applies for the top most layer at this time. 