### PR TITLE
query response time

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -197,7 +197,7 @@ type Result struct {
 	sql          string
 	role         string
 	cacheControl string
-
+	ResponseTime int64
 	Errors     []Error         `json:"errors,omitempty"`
 	Data       json.RawMessage `json:"data,omitempty"`
 	Extensions *extensions     `json:"extensions,omitempty"`


### PR DESCRIPTION
now response time of the GraphQL API can be logged. 