### PR TITLE
PoC Add the ability for nested order by

### DIFF
--- a/core/internal/psql/query.go
+++ b/core/internal/psql/query.go
@@ -565,12 +565,19 @@ func (c *compilerContext) renderRecursiveGroupBy(sel *qcode.Select) {
 }
 
 func (c *compilerContext) renderOrderBy(sel *qcode.Select) {
-	if len(sel.OrderBy) == 0 {
+	if len(sel.OrderByWrapper.OrderBy) == 0 && len(sel.OrderBy) == 0 && sel.OrderByWrapper.Exp == nil {
 		return
 	}
 	c.w.WriteString(` ORDER BY `)
-	for i, col := range sel.OrderBy {
-		if i != 0 {
+
+	if sel.OrderByWrapper.Exp != nil {
+		// Add extra logic if order by contains a exp
+		c.renderExp(sel.Ti, sel.OrderByWrapper.Exp, false)
+		c.w.WriteString(` `)
+		c.w.WriteString(sel.OrderByWrapper.Exp.Order.String())
+	}
+	for i, col := range append(sel.OrderByWrapper.OrderBy, sel.OrderBy...) {
+		if i != 0 || sel.OrderByWrapper.Exp != nil {
 			c.w.WriteString(`, `)
 		}
 		c.colWithTable(sel.Table, col.Col.Name)

--- a/core/internal/psql/query_test.go
+++ b/core/internal/psql/query_test.go
@@ -19,6 +19,21 @@ func simpleQuery(t *testing.T) {
 	compileGQLToPSQL(t, gql, nil, "user")
 }
 
+func withNestedOrderBy(t *testing.T) {
+	gql := `query {
+	               products(
+	                       where: { and: {customer: { email: { eq: "http" }}, not: { customer: { email: { eq: ".com"}  }}}}
+	                       order_by: { customer: { email: desc }}
+	               ) {
+	                       id
+	                       user {
+	                               id
+	                       }
+	               }
+	       }`
+
+	compileGQLToPSQL(t, gql, nil, "user")
+}
 func withVariableLimit(t *testing.T) {
 	gql := `query {
 		products(limit: $limit) {
@@ -651,6 +666,7 @@ func TestCompileQuery(t *testing.T) {
 	t.Run("simpleQuery", simpleQuery)
 	t.Run("withVariableLimit", withVariableLimit)
 	t.Run("withComplexArgs", withComplexArgs)
+	t.Run("withNestedOrderBy", withNestedOrderBy)
 	t.Run("withWhereIn", withWhereIn)
 	t.Run("withWhereAndList", withWhereAndList)
 	t.Run("withWhereIsNull", withWhereIsNull)

--- a/core/query1_test.go
+++ b/core/query1_test.go
@@ -113,6 +113,34 @@ func Example_queryWithDynamicOrderBy() {
 	// {"products": [{"id": 5, "price": 15.5}, {"id": 4, "price": 14.5}, {"id": 3, "price": 13.5}, {"id": 2, "price": 12.5}, {"id": 1, "price": 11.5}]}
 	// {"products": [{"id": 1, "price": 11.5}, {"id": 2, "price": 12.5}, {"id": 3, "price": 13.5}, {"id": 4, "price": 14.5}, {"id": 5, "price": 15.5}]}
 }
+func Example_queryWithNestedOrderBy() {
+	gql := `query getProducts {
+				products(order_by: { users: { email: desc }, id: desc}, where: { id: { lt: 6 } }, limit: 5) {
+					id
+					price
+				}
+	       }`
+
+	conf := &core.Config{
+		DBType:           dbType,
+		DisableAllowList: true,
+	}
+
+	gj, err := core.NewGraphJin(conf, db)
+	if err != nil {
+		panic(err)
+	}
+
+	res1, err1 := gj.GraphQL(context.Background(), gql, nil, nil)
+	if err1 != nil {
+		fmt.Print(res1.SQL())
+		fmt.Println(err1)
+	} else {
+		fmt.Println(string(res1.Data))
+	}
+
+	// Output: {"products": [{"id": 5, "price": 15.5}, {"id": 4, "price": 14.5}, {"id": 3, "price": 13.5}, {"id": 2, "price": 12.5}, {"id": 1, "price": 11.5}]}
+}
 
 func Example_queryWithLimitOffsetOrderByDistinctAndWhere() {
 	gql := `query {


### PR DESCRIPTION
I have added the ability for nested order by to graphjin.

example
order_by: { users: { email: desc }}
The following piece of graphql is converted in the following query
ORDER BY ( SELECT MIN(email) FROM users WHERE (("users".id) = ("products".owner_id))) DESC

Solution
The solution is using the nested where functionality and applying this on order by statements. I have added a OrderByWrapper field to the Select structure. This wrapper combines the Exp and old OrderBy structure so you can use both methods together. Moving the entire OrderBy structure to an Exp structure is a more elegant solution but involves a lot of refactoring also on the cursor functionality.

ToDo

    When using multiple nested order by's only 1 is processed.
    Cursor functionality is not using the OrderByWrapper structure
