### PR TITLE
Introspection of db functions

### DIFF
--- a/core/internal/sdata/sql.go
+++ b/core/internal/sdata/sql.go
@@ -14,6 +14,7 @@ RIGHT JOIN
 	ON (r.specific_name = p.specific_name and p.ordinal_position IS NOT NULL)	
 WHERE 
 	p.specific_schema NOT IN ('information_schema', 'performance_schema', 'pg_catalog', 'mysql', 'sys')
+AND r.external_language NOT IN ('C')
 ORDER BY 
 	r.routine_name, p.ordinal_position;
 `

--- a/core/introspec.go
+++ b/core/introspec.go
@@ -499,7 +499,15 @@ func (in *intro) addFuncs(
 				})
 			}
 		}
-
+		fn = funcCount.name + "_" + colName
+		if in.gj.conf.EnableCamelcase {
+			fn = util.ToCamel(fn)
+		}
+		ot.Fields = append(ot.Fields, &schema.Field{
+			Name: fn,
+			Type: colType,
+			Desc: schema.NewDescription(funcCount.desc),
+		})
 		for _, f := range in.GetFunctions() {
 			fn := f.Name + "_" + colName
 			fn_type,typeName := getGQLTypeFunc(f.Params[0])

--- a/core/introspec.go
+++ b/core/introspec.go
@@ -500,20 +500,20 @@ func (in *intro) addFuncs(
 			}
 		}
 
-		for _, fn := range in.GetFunctions() {
-			fn_name := fn.Name + "_" + colName
-			fn_type,typeName := getGQLTypeFunc(fn.Params[0])
+		for _, f := range in.GetFunctions() {
+			fn := f.Name + "_" + colName
+			fn_type,typeName := getGQLTypeFunc(f.Params[0])
 			_,colTypeName := getGQLType(col, false)
 			if typeName != colTypeName {
 				continue
 			}
 
-			fName := fn.Name + "_" + colName
+			fName := f.Name + "_" + colName
 			if in.gj.conf.EnableCamelcase {
-				fn_name = util.ToCamel(fName)
+				fn = util.ToCamel(fName)
 			}
 			ot.Fields = append(ot.Fields, &schema.Field{
-				Name: fn_name,
+				Name: fn,
 				Type: fn_type,
 			})
 		}


### PR DESCRIPTION
Issues that were fixed:
- Database functions that are not written by the DBA should not be loaded into the GraphQL Schema
- Database functions that are written by the DBA should be loaded into the GraphQL schema. (There was a bug with this functionality with ensuring that the appropriate functions were appended to the right fields in db of the matching input data type). 