### PR TITLE
Better migrations information

### DIFF
--- a/internal/cmd/cmd_migrate.go
+++ b/internal/cmd/cmd_migrate.go
@@ -128,7 +128,7 @@ func cmdDBMigrate() func(*cobra.Command, []string) {
 		}
 
 		if err != nil {
-			log.Fatalf("Encountered error: %s", err)
+			log.Fatalf("Error with migrations: %s", err)
 
 			// if err, ok := err.(m.MigrationPgError); ok {
 			// 	if err.Detail != "" {

--- a/internal/cmd/cmd_migrate.go
+++ b/internal/cmd/cmd_migrate.go
@@ -62,7 +62,7 @@ func cmdDBMigrate() func(*cobra.Command, []string) {
 			} else {
 				log.Fatalf("Migration direction %s not supported", direction)
 			}
-			log.Infof("%15s %s", action, name)
+			log.Infof("%s %s", action, name)
 
 			if conf.Debug {
 				log.Infof("SQL:\n%s", sql)
@@ -80,13 +80,13 @@ func cmdDBMigrate() func(*cobra.Command, []string) {
 			} else {
 				log.Fatalf("Migration direction %s not supported", direction)
 			}
-			log.Infof("%15s %s (%d ms)", action, name, durationMs)
+			log.Infof("%s %s (%d ms)", action, name, durationMs)
 		}
 
 		m.OnError = func(name string, err error, sql string) {
 			sql = strings.TrimSpace(sql)
 			sql = "> " + strings.ReplaceAll(sql, "\n", "\n> ")
-			log.Infof("Error in %s:\n%s\n\n%s", name, sql, err)
+			log.Infof("Error in %s:\n%s\n%s", name, sql, err)
 		}
 
 		currentVersion, err := m.GetCurrentVersion()

--- a/internal/cmd/cmd_migrate.go
+++ b/internal/cmd/cmd_migrate.go
@@ -86,7 +86,7 @@ func cmdDBMigrate() func(*cobra.Command, []string) {
 		m.OnError = func(name string, err error, sql string) {
 			sql = strings.TrimSpace(sql)
 			sql = "> " + strings.ReplaceAll(sql, "\n", "\n> ")
-			log.Infof("Error in %s:\n%s\n%s", name, sql, err)
+			log.Infof("Error in %s\n%s\n%s", name, sql, err)
 		}
 
 		currentVersion, err := m.GetCurrentVersion()

--- a/internal/cmd/cmd_migrate.go
+++ b/internal/cmd/cmd_migrate.go
@@ -84,7 +84,9 @@ func cmdDBMigrate() func(*cobra.Command, []string) {
 		}
 
 		m.OnError = func(name string, err error, sql string) {
-			log.Infof("Error in %s:\n%s\n----\n%s", name, sql, err)
+			sql = strings.TrimSpace(sql)
+			sql = "> " + strings.ReplaceAll(sql, "\n", "\n> ")
+			log.Infof("Error in %s:\n%s\n\n%s", name, sql, err)
 		}
 
 		currentVersion, err := m.GetCurrentVersion()

--- a/internal/cmd/cmd_migrate.go
+++ b/internal/cmd/cmd_migrate.go
@@ -147,7 +147,7 @@ func cmdDBMigrate() func(*cobra.Command, []string) {
 			// }
 		}
 
-		if doneSomething == false {
+		if !doneSomething {
 			log.Infof("Nothing to do")
 		}
 

--- a/internal/cmd/internal/migrate/migrate.go
+++ b/internal/cmd/internal/migrate/migrate.go
@@ -334,7 +334,9 @@ func (m *Migrator) MigrateTo(targetVersion int32) (err error) {
 			// if err, ok := err.(pgx.PgError); ok {
 			// 	return MigrationPgError{Sql: sql, PgError: err}
 			// }
-			m.OnError(current.Name, err, sql)
+			if m.OnError != nil {
+				m.OnError(current.Name, err, sql)
+			}
 			return fmt.Errorf("SQL Error")
 		}
 

--- a/internal/cmd/internal/migrate/migrate.go
+++ b/internal/cmd/internal/migrate/migrate.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -68,8 +69,10 @@ type Migrator struct {
 	versionTable string
 	options      *MigratorOptions
 	Migrations   []*Migration
-	OnStart      func(int32, string, string, string) // OnStart is called when a migration is run with the sequence, name, direction, and SQL
-	Data         map[string]interface{}              // Data available to use in migrations
+	OnStart      func(name string, direction string, sql string) // OnStart is called when a migration is being run
+	OnFinish     func(name string, direction string, durationMs int64)
+	OnError      func(name string, err error, sql string)
+	Data         map[string]interface{} // Data available to use in migrations
 }
 
 func NewMigrator(db *sql.DB, versionTable string) (m *Migrator, err error) {
@@ -312,6 +315,8 @@ func (m *Migrator) MigrateTo(targetVersion int32) (err error) {
 
 		ctx := context.Background()
 
+		start := time.Now()
+
 		tx, err := m.db.BeginTx(ctx, nil)
 		if err != nil {
 			return err
@@ -320,7 +325,7 @@ func (m *Migrator) MigrateTo(targetVersion int32) (err error) {
 
 		// Fire on start callback
 		if m.OnStart != nil {
-			m.OnStart(current.Sequence, current.Name, directionName, sql)
+			m.OnStart(current.Name, directionName, sql)
 		}
 
 		// Execute the migration
@@ -329,7 +334,8 @@ func (m *Migrator) MigrateTo(targetVersion int32) (err error) {
 			// if err, ok := err.(pgx.PgError); ok {
 			// 	return MigrationPgError{Sql: sql, PgError: err}
 			// }
-			return err
+			m.OnError(current.Name, err, sql)
+			return fmt.Errorf("SQL Error")
 		}
 
 		// Reset all database connection settings. Important to do before updating version as search_path may have been changed.
@@ -348,7 +354,13 @@ func (m *Migrator) MigrateTo(targetVersion int32) (err error) {
 			return err
 		}
 
+		duration := time.Since(start)
+
 		currentVersion = currentVersion + direction
+
+		if m.OnFinish != nil {
+			m.OnFinish(current.Name, directionName, duration.Milliseconds())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This pull request adds information about migrations being done and problems with them.

## Previously

Error in a migration:

```console
$ graphjin db:migrate up
FATAL   Error with migrations: ERROR: syntax error at or near "inZert" (SQLSTATE 42601)
```

Which migration? Where?

After a fix to a migration:

```console
$ graphjin db:migrate up
INFO    Migrations completed
```

This applied a migration called `2_update_tags`, but we don't know that.

```console
$ graphjin db:migrate up
INFO    Migrations completed
```

This second "up" actually did nothing, but we don't know that.

```console
$ graphjin db:migrate down
INFO    Migrations completed
```

What was rolled back here? One, two? Which ones?

## After this pull request

Error in a migration:

```console
INFO    Migrating:  2_update_tags.sql
INFO    Error in 2_update_tags.sql
> insert into tags select generate_series(1, 10000);
> insert into tags select generate_series(1, 10000);
> inZert into tags select generate_series(1, 10000);
ERROR: syntax error at or near "inZert" (SQLSTATE 42601)
FATAL   Encountered error: SQL Error
```

After a fix to a migration:

```console
$ graphjin db:migrate up
INFO    Migrating:  2_update_tags.sql
INFO    Migrated:   2_update_tags.sql (29 ms)
```
```console
$ graphjin db:migrate up
INFO    Nothing to do
```
```console
$ graphjin db:migrate down
INFO    Rolling back:  2_update_tags.sql
INFO    Rolled back:   2_update_tags.sql (7 ms)
```
