### PR TITLE
Fix for auth type none

### DIFF
--- a/serv/auth/auth.go
+++ b/serv/auth/auth.go
@@ -165,7 +165,7 @@ func NewAuth(ac Auth, log *zap.Logger, opt Options) (
 
 	// case "magiclink":
 	// 	h, err = MagicLinkHandler(ac, next)
-	case "":
+	case "", "none":
 		return nil, nil
 
 	default:

--- a/serv/http.go
+++ b/serv/http.go
@@ -62,7 +62,12 @@ func apiV1Handler(s1 *Service, ns nspace) http.Handler {
 	if err != nil {
 		s.log.Fatalf("api: error initializing auth: %s", err)
 	}
-	h := useAuth(s1.apiV1(ns))
+
+	h := s1.apiV1(ns)
+	// useAuth can be nil when type="" or type="none"
+	if useAuth != nil {
+		h = useAuth(s1.apiV1(ns))
+	}
 
 	if len(s.conf.AllowedOrigins) != 0 {
 		allowedHeaders := []string{


### PR DESCRIPTION
`auth.NewAuth` can return `nil` when auth `type=""`. Added `nil` check along with type="". See https://discord.com/channels/628796009539043348/628796009539043350/973293514538512465

`type=""` seems redundant though. Thoughts?