### PR TITLE
Cue validation for query and mutations variables

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	cuejson "cuelang.org/go/encoding/json"
 	"github.com/avast/retry-go"
 	"github.com/dosco/graphjin/core/internal/psql"
 	"github.com/dosco/graphjin/core/internal/qcode"
@@ -356,6 +357,14 @@ func (c *gcontext) validateAndUpdateVars(qcomp *queryComp, res *queryResp) error
 
 	if len(qr.vars) != 0 {
 		if err := json.Unmarshal(qr.vars, &vars); err != nil {
+			return err
+		}
+	}
+	if qc.Validation != nil {
+		if err := cuejson.Validate(qr.vars, qc.Validation.Cuev); err != nil {
+			// TODO: better error handling. it's not clear that error came from validation
+			// aslo it needs to be able to parse in frontend,
+			// ex: error:{kind:"validation",problem:"out of range",path:"input.id",shoud_be:"<5"}
 			return err
 		}
 	}

--- a/core/introspec.go
+++ b/core/introspec.go
@@ -398,8 +398,8 @@ func (in *intro) addDirectives() {
 	}
 	in.DeclaredDirectives["validation"] = &schema.DirectiveDecl{
 		Name: "validation",
-		Desc: schema.NewDescription("Checks all variables for vaidation"),
-		Locs: []string{"FIELD"},
+		Desc: schema.NewDescription("Checks all variables for validation"),
+		Locs: []string{"QUERY", "MUTATION", "SUBSCRIPTION"},
 		Args: schema.InputValueList{
 			{
 				Name: "cue",

--- a/core/introspec.go
+++ b/core/introspec.go
@@ -396,6 +396,18 @@ func (in *intro) addDirectives() {
 			},
 		},
 	}
+	in.DeclaredDirectives["validation"] = &schema.DirectiveDecl{
+		Name: "validation",
+		Desc: schema.NewDescription("Checks all variables for vaidation"),
+		Locs: []string{"FIELD"},
+		Args: schema.InputValueList{
+			{
+				Name: "cue",
+				Desc: schema.NewDescription("Use Cue [https://cuelang.org/] schema to validate variables"),
+				Type: &schema.TypeName{Name: "String"},
+			},
+		},
+	}
 }
 
 func (in *intro) addColumn(

--- a/core/query2_test.go
+++ b/core/query2_test.go
@@ -389,8 +389,8 @@ func BenchmarkCompile(b *testing.B) {
 	}
 }
 func TestCueValidationQuerySingleIntVarValue(t *testing.T) {
-	gql := `query {
-		users(where: {id:$id}) @validation(cue:"id:2") {
+	gql := `query @validation(cue:"id:2") {
+		users(where: {id:$id}) {
 		  id
 		  full_name
 		  email
@@ -409,8 +409,8 @@ func TestCueValidationQuerySingleIntVarValue(t *testing.T) {
 	}
 }
 func TestCueInvalidationQuerySingleIntVarValue(t *testing.T) {
-	gql := `query {
-		users(where: {id:$id}) @validation(cue:"id:2") {
+	gql := `query @validation(cue:"id:2") {
+		users(where: {id:$id}) {
 		  id
 		  full_name
 		  email
@@ -429,8 +429,8 @@ func TestCueInvalidationQuerySingleIntVarValue(t *testing.T) {
 	}
 }
 func TestCueValidationQuerySingleIntVarType(t *testing.T) {
-	gql := `query {
-		users(where: {id:$id}) @validation(cue:"id:int") {
+	gql := `query @validation(cue:"id:int") {
+		users(where: {id:$id}) {
 		  id
 		  full_name
 		  email
@@ -449,8 +449,8 @@ func TestCueValidationQuerySingleIntVarType(t *testing.T) {
 	}
 }
 func TestCueValidationQuerySingleIntVarOR(t *testing.T) {
-	gql := `query {
-		users(where: {id:$id}) @validation(cue:"id: 3 | 2") {
+	gql := `query @validation(cue:"id: 3 | 2") {
+		users(where: {id:$id}) {
 		  id
 		  full_name
 		  email
@@ -469,8 +469,8 @@ func TestCueValidationQuerySingleIntVarOR(t *testing.T) {
 	}
 }
 func TestCueInvalidationQuerySingleIntVarOR(t *testing.T) {
-	gql := `query {
-		users(where: {id:$id}) @validation(cue:"id: 3 | 2") {
+	gql := `query @validation(cue:"id: 3 | 2") {
+		users(where: {id:$id}) {
 		  id
 		  full_name
 		  email
@@ -491,8 +491,8 @@ func TestCueInvalidationQuerySingleIntVarOR(t *testing.T) {
 func TestCueValidationQuerySingleStringVarOR(t *testing.T) {
 	// TODO: couldn't find a way to pass string inside cue through plain graphql query ( " )
 	// (only way is using varibales and escape \")
-	gql := `query {
-		users(where: {email:$mail}) @validation(cue:$validation) {
+	gql := `query @validation(cue:$validation) {
+		users(where: {email:$mail}) {
 		  id
 		  full_name
 		  email
@@ -511,8 +511,8 @@ func TestCueValidationQuerySingleStringVarOR(t *testing.T) {
 	}
 }
 func TestCueInvalidationQuerySingleStringVarOR(t *testing.T) {
-	gql := `query {
-		users(where: {email:$mail}) @validation(cue:$validation) {
+	gql := `query @validation(cue:$validation) {
+		users(where: {email:$mail}) {
 		  id
 		  full_name
 		  email
@@ -531,8 +531,8 @@ func TestCueInvalidationQuerySingleStringVarOR(t *testing.T) {
 	}
 }
 func TestCueInvalidationQuerySingleIntVarType(t *testing.T) {
-	gql := `query {
-		users(where: {email:$email}) @validation(cue:"email:int") {
+	gql := `query @validation(cue:"email:int") {
+		users(where: {email:$email}) {
 		  id
 		  full_name
 		  email
@@ -551,8 +551,8 @@ func TestCueInvalidationQuerySingleIntVarType(t *testing.T) {
 	}
 }
 func TestCueValidationMutationMapVarStringsLen(t *testing.T) {
-	gql := `mutation {
-		users(insert:$inp) @validation(cue:$validation) {
+	gql := `mutation @validation(cue:$validation) {
+		users(insert:$inp) {
 		  id
 		  full_name
 		  email
@@ -576,8 +576,8 @@ func TestCueValidationMutationMapVarStringsLen(t *testing.T) {
 	}
 }
 func TestCueInvalidationMutationMapVarStringsLen(t *testing.T) {
-	gql := `mutation {
-		users(insert:$inp) @validation(cue:$validation) {
+	gql := `mutation @validation(cue:$validation) {
+		users(insert:$inp) {
 		  id
 		  full_name
 		  email
@@ -602,8 +602,8 @@ func TestCueInvalidationMutationMapVarStringsLen(t *testing.T) {
 }
 
 func TestCueValidationMutationMapVarIntMaxMin(t *testing.T) {
-	gql := `mutation {
-		users(insert:$inp) @validation(cue:$validation) {
+	gql := `mutation @validation(cue:$validation) {
+		users(insert:$inp) {
 		  id
 		  full_name
 		  email
@@ -627,8 +627,8 @@ func TestCueValidationMutationMapVarIntMaxMin(t *testing.T) {
 	}
 }
 func TestCueInvalidationMutationMapVarIntMaxMin(t *testing.T) {
-	gql := `mutation {
-		users(insert:$inp) @validation(cue:$validation) {
+	gql := `mutation @validation(cue:$validation) {
+		users(insert:$inp) {
 		  id
 		  full_name
 		  email
@@ -652,8 +652,8 @@ func TestCueInvalidationMutationMapVarIntMaxMin(t *testing.T) {
 	}
 }
 func TestCueValidationMutationMapVarOptionalKey(t *testing.T) {
-	gql := `mutation {
-		users(insert:$inp) @validation(cue:$validation) {
+	gql := `mutation @validation(cue:$validation) {
+		users(insert:$inp) {
 		  id
 		  full_name
 		  email
@@ -677,8 +677,8 @@ func TestCueValidationMutationMapVarOptionalKey(t *testing.T) {
 	}
 }
 func TestCueValidationMutationMapVarRegex(t *testing.T) {
-	gql := `mutation {
-		users(insert:$inp) @validation(cue:$validation) {
+	gql := `mutation @validation(cue:$validation) {
+		users(insert:$inp) {
 		  id
 		  full_name
 		  email
@@ -702,8 +702,8 @@ func TestCueValidationMutationMapVarRegex(t *testing.T) {
 	}
 }
 func TestCueInvalidationMutationMapVarRegex(t *testing.T) {
-	gql := `mutation {
-		users(insert:$inp) @validation(cue:$validation) {
+	gql := `mutation @validation(cue:$validation) {
+		users(insert:$inp) {
 		  id
 		  full_name
 		  email

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.10
 	contrib.go.opencensus.io/exporter/zipkin v0.1.2
 	contrib.go.opencensus.io/integrations/ocsql v0.1.7
+	cuelang.org/go v0.4.3
 	filippo.io/age v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go v63.1.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.25 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,7 +72,10 @@ contrib.go.opencensus.io/exporter/zipkin v0.1.2 h1:YqE293IZrKtqPnpwDPH/lOqTWD/s3
 contrib.go.opencensus.io/exporter/zipkin v0.1.2/go.mod h1:mP5xM3rrgOjpn79MM8fZbj3gsxcuytSqtH0dxSWW1RE=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7 h1:G3k7C0/W44zcqkpRSFyjU9f6HZkbwIrL//qqnlqWZ60=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
+cuelang.org/go v0.4.3 h1:W3oBBjDTm7+IZfCKZAmC8uDG0eYfJL4Pp/xbbCMKaVo=
+cuelang.org/go v0.4.3/go.mod h1:7805vR9H+VoBNdWFdI7jyDR3QLUPp4+naHfbcgp55HI=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/age v1.0.0-beta7/go.mod h1:chAuTrTb0FTTmKtvs6fQTGhYTvH9AigjN1uEUsvLdZ0=
 filippo.io/age v1.0.0 h1:V6q14n0mqYU3qKFkZ6oOaF9oXneOviS3ubXsSVBRSzc=
 filippo.io/age v1.0.0/go.mod h1:PaX+Si/Sd5G8LgfCwldsSba3H1DDQZhIhFGkhbHaBq8=
@@ -263,6 +266,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
+github.com/cockroachdb/apd/v2 v2.0.1 h1:y1Rh3tEU89D+7Tgbw+lp52T6p/GJLpDmNvr10UWqLTE=
+github.com/cockroachdb/apd/v2 v2.0.1/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -436,6 +441,7 @@ github.com/elastic/go-elasticsearch/v7 v7.16.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyEr
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/proto v1.6.15/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -911,6 +917,7 @@ github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
@@ -1019,6 +1026,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=
+github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -1170,6 +1179,7 @@ github.com/prometheus/statsd_exporter v0.21.0/go.mod h1:rbT83sZq2V+p73lHhPZfMc3M
 github.com/prometheus/statsd_exporter v0.22.4 h1:bGhC0iI9DM8m9KIUlbcr3uzXnopagrajEKoP790256k=
 github.com/prometheus/statsd_exporter v0.22.4/go.mod h1:N4Z1+iSqc9rnxlT1N8Qn3l65Vzb5t4Uq0jpg8nxyhio=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc/go.mod h1:KbKfKPy2I6ecOIGA9apfheFv14+P3RSmmQvshofQyMY=
 github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -1414,6 +1424,7 @@ golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
@@ -1421,6 +1432,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20210126221216-84987778548c/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1437,12 +1449,15 @@ golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
+golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -1725,6 +1740,7 @@ golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200122220014-bf1340f18c4a/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200128220307-520188d60f50/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
@@ -1742,6 +1758,7 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200612220849-54c614fe050c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=


### PR DESCRIPTION
checkout tests for examples.

limitations: 
1. only works with variables. can not find a way to cast field args into json or struct. 
2. can not use string inside cue schema (double quote " problem) inside plain graphql query, but it can be done with passing validation schema through variables.