### PR TITLE
Fix: lexer support mutations with JSON fields

### DIFF
--- a/core/internal/graph/lex.go
+++ b/core/internal/graph/lex.go
@@ -317,19 +317,27 @@ func lexString(l *lexer) stateFn {
 	if sr, ok := l.accept([]byte(quotesToken)); ok {
 		l.ignore()
 
+		var escaped bool
 		for {
 			r := l.next()
 			if r == eof {
 				l.emit(itemEOF)
 				return nil
 			}
-			if r == sr {
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if !escaped && r == sr {
 				l.backup()
 				l.emit(itemStringVal)
 				if _, ok := l.accept(quotesToken); ok {
 					l.ignore()
 				}
 				break
+			}
+			if escaped {
+				escaped = false
 			}
 		}
 	}

--- a/core/internal/graph/lex_test.go
+++ b/core/internal/graph/lex_test.go
@@ -1,0 +1,46 @@
+package graph
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func Test_lex_JSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		json     string
+		jsonItem int
+	}{
+		{
+			name:     "json",
+			input:    []byte("{\"id\":1,\"json\":\"{\\\"field1\\\":\\\"value1\\\", \\\"field2\\\":\\\"value2\\\"}\"}"),
+			json:     "{\"field1\":\"value1\", \"field2\":\"value2\"}",
+			jsonItem: 6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := lex(tt.input)
+			if err != nil {
+				t.Fatalf("lex() error = %v", err)
+			}
+			if len(got.items) < tt.jsonItem {
+				t.Fatal("lex() invalid items count")
+			}
+			j := got.items[tt.jsonItem]
+			if j.String() != "string" {
+				t.Fatal("lex() invalid type")
+			}
+			mapStructure := map[string]interface{}{}
+			err = json.Unmarshal(tt.input, &mapStructure)
+			if err != nil {
+				t.Fatalf("json.Unmarshal error = %v", err)
+			}
+			if !reflect.DeepEqual(mapStructure["json"], tt.json) {
+				t.Fatalf("lex() JSON = %v, want %v", got, tt.json)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is for support JSON fields in the mutation vars. Without this fix it fails with "unrecognized character in action"