### PR TITLE
 Fix: support CamelCase nested table vars

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -175,9 +175,10 @@ func (gj *graphjin) initCompilers() error {
 	}
 
 	gj.pc = psql.NewCompiler(psql.Config{
-		Vars:      gj.conf.Vars,
-		DBType:    gj.schema.DBType(),
-		DBVersion: gj.schema.DBVersion(),
+		Vars:            gj.conf.Vars,
+		DBType:          gj.schema.DBType(),
+		DBVersion:       gj.schema.DBVersion(),
+		EnableCamelcase: gj.conf.EnableCamelcase,
 	})
 	return nil
 }

--- a/core/internal/psql/mutate.go
+++ b/core/internal/psql/mutate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dosco/graphjin/core/internal/graph"
 	"github.com/dosco/graphjin/core/internal/qcode"
 	"github.com/dosco/graphjin/core/internal/sdata"
+	"github.com/dosco/graphjin/core/internal/util"
 )
 
 func (co *Compiler) compileMutation(
@@ -536,7 +537,7 @@ func (c *compilerContext) renderMutateToRecordSet(m qcode.Mutate, n int) {
 	}
 
 	c.w.WriteString(`(`)
-	joinPath(c.w, `i.j`, m.Path)
+	joinPath(c.w, `i.j`, m.Path, c.enableCamelcase)
 	c.w.WriteString(`) as t(`)
 
 	i := 0
@@ -559,12 +560,16 @@ func (c *compilerContext) renderComma(i int) int {
 	return i + 1
 }
 
-func joinPath(w *bytes.Buffer, prefix string, path []string) {
+func joinPath(w *bytes.Buffer, prefix string, path []string, enableCamelcase bool) {
 	w.WriteString(prefix)
 	for i := range path {
 		w.WriteString(`->`)
 		w.WriteString(`'`)
-		w.WriteString(path[i])
+		if enableCamelcase {
+			w.WriteString(util.ToCamel(path[i]))
+		} else {
+			w.WriteString(path[i])
+		}
 		w.WriteString(`'`)
 	}
 }

--- a/core/internal/psql/query.go
+++ b/core/internal/psql/query.go
@@ -39,19 +39,21 @@ type compilerContext struct {
 type Variables map[string]json.RawMessage
 
 type Config struct {
-	Vars      map[string]string
-	DBType    string
-	DBVersion int
+	Vars            map[string]string
+	DBType          string
+	DBVersion       int
+	EnableCamelcase bool
 }
 
 type Compiler struct {
-	svars map[string]string
-	ct    string // db type
-	cv    int    // db version
+	svars           map[string]string
+	ct              string // db type
+	cv              int    // db version
+	enableCamelcase bool
 }
 
 func NewCompiler(conf Config) *Compiler {
-	return &Compiler{svars: conf.Vars, ct: conf.DBType, cv: conf.DBVersion}
+	return &Compiler{svars: conf.Vars, ct: conf.DBType, cv: conf.DBVersion, enableCamelcase: conf.EnableCamelcase}
 }
 
 func (co *Compiler) CompileEx(qc *qcode.QCode) (Metadata, []byte, error) {

--- a/core/query1_test.go
+++ b/core/query1_test.go
@@ -947,7 +947,7 @@ func Example_queryWithRemoteAPIJoin() {
 			fmt.Fprintf(w, `{"data":[{"desc":"Payment 1 for %s"},{"desc": "Payment 2 for %s"}]}`,
 				id, id)
 		})
-		log.Fatal(http.ListenAndServe("localhost:12345", nil))
+		log.Fatal(http.ListenAndServe("localhost:12345", nil)) //nolint:gosec
 	}()
 
 	conf := newConfig(&core.Config{DBType: dbType, DisableAllowList: true, DefaultLimit: 2})

--- a/wasm/httpd.go
+++ b/wasm/httpd.go
@@ -25,5 +25,5 @@ func main() {
 		}
 	})
 	log.Println("WARM testing server started on port 8080")
-	log.Println(http.ListenAndServe(":8080", nil))
+	log.Println(http.ListenAndServe(":8080", nil)) //nolint:gosec
 }


### PR DESCRIPTION
Hi, don't know if this is OK to PR, but take a look to it, I use this code to fix  support  nested table vars when EnableCamelcase is used. Like:

```json
{
  "data": {
    "visitorId": 1025,
    "deviceAssignments": {
      "deviceId": 4097
    }
  },
}
```

Without the fix, in the vars "deviceAssignments" has to be ssend as "device_assignments".
