### PR TITLE
Fix: add filling field rc of graphqlReq struct

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -434,6 +434,9 @@ func (gj *graphjin) newGraphqlReq(rc *ReqConfig,
 		vars:  vars,
 	}
 
+	if rc != nil {
+		r.rc = rc
+	}
 	if rc != nil && rc.ns != nil {
 		r.ns = *rc.ns
 	} else {


### PR DESCRIPTION
`newGraphqlReq()` doesn't write ReqConfig to struct.

graphjin\core\api.go:424
```go
func (gj *graphjin) newGraphqlReq(rc *ReqConfig,
	op string,
	name string,
	query []byte,
	vars json.RawMessage,
) (r graphqlReq) {
	r = graphqlReq{
		op:    qcode.GetQTypeByName(op),
		name:  name,
		query: query,
		vars:  vars,
	}

	if rc != nil && rc.ns != nil { // the r.rc is not set, only r.ns
		r.ns = *rc.ns
	} else {
		r.ns = gj.namespace
	}
	return
}
```

Field `graphqlReq.rc` is not initialized, so `tx()` will never return a transaction, making it impossible to use.
_graphjin\core\gstate.go:355_
```go
func (s *gstate) tx() (tx *sql.Tx) {
	if s.r.rc != nil { // s.r.rc is always nil!
		tx = s.r.rc.Tx
	}
	return
}
```

This PR fixes the bug.