### PR TITLE
remove unused fragmentPath variable

### DIFF
--- a/core/internal/allow/allow.go
+++ b/core/internal/allow/allow.go
@@ -22,8 +22,7 @@ type FS interface {
 var ErrUnknownGraphQLQuery = errors.New("unknown graphql query")
 
 const (
-	queryPath    = "/queries"
-	fragmentPath = "/fragments"
+	queryPath = "/queries"
 )
 
 type Item struct {


### PR DESCRIPTION
It appears to be the case that `fragmentPath` is not used anywhere. To avoid confusion, I am removing it. 