### PR TITLE
Refactor/clarity

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -271,6 +271,7 @@ func (rc *ReqConfig) SetNamespace(ns string) {
 	rc.ns = &ns
 }
 
+// GetNamespace is used to get the namespace requests within a single instance of GraphJin
 func (rc *ReqConfig) GetNamespace() (string, bool) {
 	if rc.ns != nil {
 		return *rc.ns, true
@@ -445,6 +446,7 @@ func (gj *graphjin) newGraphqlReq(rc *ReqConfig,
 	return
 }
 
+// Set is used to set the namespace, operation type, name and query for the GraphQL request
 func (r *graphqlReq) Set(item allow.Item) {
 	r.ns = item.Namespace
 	r.op = qcode.GetQTypeByName(item.Operation)
@@ -453,11 +455,13 @@ func (r *graphqlReq) Set(item allow.Item) {
 	r.aschema = item.ActionJSON
 }
 
+// GraphQL function is our main function it takes a GraphQL query compiles it
 func (gj *graphjin) queryWithResult(c context.Context, r graphqlReq) (res *Result, err error) {
 	resp, err := gj.query(c, r)
 	return &resp.res, err
 }
 
+// GraphQL function is our main function it takes a GraphQL query compiles it
 func (gj *graphjin) query(c context.Context, r graphqlReq) (
 	resp graphqlResp, err error,
 ) {

--- a/core/core.go
+++ b/core/core.go
@@ -68,6 +68,7 @@ func (gj *graphjin) getIntroResult() (data json.RawMessage, err error) {
 	return
 }
 
+// Initializes the database discovery process on graphjin
 func (gj *graphjin) initDiscover() (err error) {
 	switch gj.conf.DBType {
 	case "":
@@ -84,6 +85,7 @@ func (gj *graphjin) initDiscover() (err error) {
 	return
 }
 
+// Private method that does the actual database discovery for initDiscover
 func (gj *graphjin) _initDiscover() (err error) {
 	if gj.prod && gj.conf.EnableSchema {
 		b, err := gj.fs.Get("db.graphql")
@@ -129,6 +131,7 @@ func (gj *graphjin) _initDiscover() (err error) {
 	return
 }
 
+// Initializes the database schema on graphjin
 func (gj *graphjin) initSchema() error {
 	if err := gj._initSchema(); err != nil {
 		return fmt.Errorf("%s: %w", gj.dbtype, err)
@@ -186,6 +189,7 @@ func (gj *graphjin) _initSchema() (err error) {
 	return
 }
 
+// Initializes the qcode compilers
 func (gj *graphjin) initCompilers() (err error) {
 	qcc := qcode.Config{
 		TConfig:         gj.tmap,
@@ -273,6 +277,7 @@ func (gj *graphjin) executeRoleQuery(c context.Context,
 	return
 }
 
+// Returns the operation type for the query result
 func (r *Result) Operation() OpType {
 	switch r.op {
 	case qcode.QTQuery:
@@ -286,26 +291,32 @@ func (r *Result) Operation() OpType {
 	}
 }
 
+// Returns the namespace for the query result
 func (r *Result) Namespace() string {
 	return r.ns
 }
 
+// Returns the operation name for the query result
 func (r *Result) OperationName() string {
 	return r.op.String()
 }
 
+// Returns the query name for the query result
 func (r *Result) QueryName() string {
 	return r.name
 }
 
+// Returns the role used to execute the query
 func (r *Result) Role() string {
 	return r.role
 }
 
+// Returns the SQL query string for the query result
 func (r *Result) SQL() string {
 	return r.sql
 }
 
+// Returns the cache control header value for the query result
 func (r *Result) CacheControl() string {
 	return r.cacheControl
 }
@@ -370,6 +381,7 @@ func (s *gstate) debugLogStmt() {
 	}
 }
 
+// Saved the query qcode to the allow list
 func (gj *graphjin) saveToAllowList(qc *qcode.QCode, ns string) (err error) {
 	if gj.conf.DisableAllowList {
 		return nil
@@ -399,10 +411,12 @@ func (gj *graphjin) saveToAllowList(qc *qcode.QCode, ns string) (err error) {
 	return gj.allowList.Set(item)
 }
 
+// Starts tracing with the given name
 func (gj *graphjin) spanStart(c context.Context, name string) (context.Context, Spaner) {
 	return gj.trace.Start(c, name)
 }
 
+// Retry operation with jittered backoff at 50, 100, 200 ms
 func retryOperation(c context.Context, fn func() error) (err error) {
 	jitter := []int{50, 100, 200}
 	for i := 0; i < 3; i++ {

--- a/core/init.go
+++ b/core/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dosco/graphjin/core/v3/internal/sdata"
 )
 
+// Initializes the graphjin instance with the config
 func (gj *graphjin) initConfig() error {
 	c := gj.conf
 


### PR DESCRIPTION
I'm starting to make some changes to the code documentation here. I'm including a bit of refactoring to make sure that things are more readable.

- The code extensively uses the short variable names to the detriment of the readability. This compounds the problem of not having enough code documentation.

- While golang recommends short variable names, the intention is to avoid long nested function calls and to avoid diverting the attention from the main logic of the program. However, even the main logic variables have really short names making it almost impossible to read.