### PR TITLE
Fixed issue where all primary key queries were mandatory in default graphjin queries

### DIFF
--- a/core/intro.go
+++ b/core/intro.go
@@ -285,11 +285,18 @@ func (in *intro) addTable(t sdata.DBTable, alias string) (err error) {
 	in.addTypeTo("Mutation", ftM)
 
 	// add tableByID type to query and subscription
-	ftQS.Name += "ByID"
-	ftQS.addOrReplaceArg("id", newTR(KIND_NONNULL, "", newTR("", "ID", nil)))
-	in.addType(ftQS)
-	in.addTypeTo("Query", ftQS)
-	in.addTypeTo("Subscription", ftQS)
+	var ftQSByID fullType
+
+	if ftQSByID, err = in.addTableType(t, alias); err != nil {
+		return
+	}
+
+	ftQSByID.Name += "ByID"
+	ftQSByID.addOrReplaceArg("id", newTR(KIND_NONNULL, "", newTR("", "ID", nil)))
+	in.addType(ftQSByID)
+	in.addTypeTo("Query", ftQSByID)
+	in.addTypeTo("Subscription", ftQSByID)
+
 	return
 }
 


### PR DESCRIPTION
- Updated the readme documentation example, fixing the issue of missing parameters, default Postgres connection URL, and a sample SQL for creating the table.
- Fixed the issue highlighted in #459  addressing the scenario outlined by @rkishasanka in #459 by creating a new entry for the fullTypeQuery for the `byID()` queries. It seems like this was a bug where the data was getting overridden for the original fullTypeQuery variable.