### PR TITLE
fix(psql-max): pagination fails with uuid field derived cursors

### DIFF
--- a/core/internal/psql/query.go
+++ b/core/internal/psql/query.go
@@ -272,6 +272,10 @@ func (c *compilerContext) renderPluralSelect(sel *qcode.Select) {
 		for i := 0; i < len(sel.OrderBy); i++ {
 			c.w.WriteString(`, MAX(__cur_`)
 			int32String(c.w, int32(i))
+			// Postgres rejects MAX(uuid)
+			if sel.OrderBy[i].Col.Type == "uuid" {
+				c.w.WriteString(`::text`)
+			}
 			c.w.WriteString(`)`)
 			// 	c.w.WriteString(`, CAST(MAX(__cur_`)
 			// 	int32String(c.w, int32(i))


### PR DESCRIPTION
Tested locally with postgres. Not familiar with MySQL typing system, please check it does not break things for it.