### PR TITLE
Fixed the parser to have the right parser query was saved

### DIFF
--- a/core/internal/graph/parse.go
+++ b/core/internal/graph/parse.go
@@ -271,7 +271,7 @@ func (p *Parser) parseOp() (op Operation, err error) {
 	}
 
 	e := p.curr().pos + 1
-	op.Query = p.input[s:e]
+	op.Query = p.input[s-1 : e]
 
 	return op, nil
 }


### PR DESCRIPTION
So this bug has been a pain in the ass for us for a very long time. This is a very patch like fix for saving the right query text @dosco it'll be good to get some feedback on why the character skip is being done.