### PR TITLE
serv: extend HTTP write deadline for MCP + workflow handlers

### DIFF
--- a/serv/mcp.go
+++ b/serv/mcp.go
@@ -292,6 +292,12 @@ func (s *HttpService) MCPHandler() http.Handler {
 			return
 		}
 
+		// MCP tool calls (notably execute_workflow) can run JS for up to
+		// MCP.WorkflowTimeout seconds. The global http.Server WriteTimeout
+		// is 10s, so without this lift the connection would be killed long
+		// before any non-trivial workflow could send its response.
+		extendDeadlineForWorkflow(w, s1.conf)
+
 		// Use request context (may contain auth info from middleware)
 		mcpSrv := s1.newMCPServerWithContext(r.Context())
 		// Use StreamableHTTPServer with stateless mode
@@ -316,6 +322,9 @@ func (s *HttpService) MCPMessageHandler() http.Handler {
 			http.Error(w, "MCP is disabled", http.StatusNotFound)
 			return
 		}
+
+		// See MCPHandler — same WriteTimeout extension applies here.
+		extendDeadlineForWorkflow(w, s1.conf)
 
 		// Use request context (may contain auth info from middleware)
 		mcpSrv := s1.newMCPServerWithContext(r.Context())

--- a/serv/workflows.go
+++ b/serv/workflows.go
@@ -39,6 +39,28 @@ var workflowCallableToolNames = map[string]struct{}{
 	"validate_where_clause": {},
 }
 
+// extendDeadlineForWorkflow lifts the per-request read/write deadlines so a
+// handler that may execute a long-running JS workflow is not killed by the
+// global http.Server WriteTimeout (10s by default in serv.go). The new
+// deadline is workflow_timeout + 30s (response serialization buffer), or
+// the default workflow timeout if MCP.WorkflowTimeout is unset.
+//
+// Falls through silently if the underlying ResponseWriter does not support
+// deadline control (test stubs, intermediaries) — the global timeout still
+// applies in that case.
+func extendDeadlineForWorkflow(w http.ResponseWriter, conf *Config) {
+	timeoutSecs := conf.MCP.WorkflowTimeout
+	if timeoutSecs <= 0 {
+		timeoutSecs = defaultWorkflowScriptTimeout
+	}
+	deadline := time.Now().Add(time.Duration(timeoutSecs+30) * time.Second)
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(deadline); err != nil {
+		return
+	}
+	_ = rc.SetReadDeadline(deadline)
+}
+
 // apiV1Workflows handles REST execution of named JS workflows.
 // Route format: /api/v1/workflows/<name>
 func (s1 *HttpService) apiV1Workflows(ns *string) http.Handler {
@@ -47,6 +69,7 @@ func (s1 *HttpService) apiV1Workflows(ns *string) http.Handler {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		s := s1.Load().(*graphjinService)
 		w.Header().Set("Content-Type", "application/json")
+		extendDeadlineForWorkflow(w, s.conf)
 
 		if len(r.RequestURI) < rLen {
 			renderErr(w, errors.New("no workflow name defined"))


### PR DESCRIPTION
## Summary

The global \`http.Server\` \`WriteTimeout\` in \`serv.go\` is hardcoded to 10 seconds. This is fine for the GraphQL endpoint (queries should be fast) but **silently kills any MCP \`execute_workflow\` call — and the REST workflow endpoint — that runs longer than 10s**, even though the workflow JS itself may legitimately run for up to \`MCP.WorkflowTimeout\` seconds (default 5, configurable to 300).

## Symptom

When a workflow takes >10s, Go's \`http.Server\` forcibly closes the TCP connection mid-handler. The workflow goroutine continues running and eventually returns, but its response is written to a closed socket. Clients see one of:

- \`fetch failed\` / \`UND_ERR_SOCKET: other side closed\` (undici)
- \`MCP proxy disconnected from upstream server\` (graphjin's own stdio bridge)
- Generic socket reset

**Server logs show nothing** because the workflow itself does not error — only the HTTP socket is severed.

## Root cause

\`serv/serv.go:64-65\`:
\`\`\`go
ReadTimeout:  10 * time.Second,
WriteTimeout: 10 * time.Second,
\`\`\`

These apply to **every** route on the server, including \`/api/v1/mcp\` and \`/api/v1/workflows/<name>\`. Workflows are the only handler that legitimately needs more time.

## Fix

Per-request deadline override on the three handlers that can execute workflows:

- \`MCPHandler\` (\`serv/mcp.go\`)
- \`MCPMessageHandler\` (\`serv/mcp.go\`)
- \`apiV1Workflows\` (\`serv/workflows.go\`)

Uses \`http.ResponseController.SetWriteDeadline\` (Go 1.20+) to lift the deadline to \`workflow_timeout + 30s\` only for those handlers. The global 10s timeout still protects every other endpoint (DoS shield on the GraphQL path is preserved).

A small helper \`extendDeadlineForWorkflow\` lives in \`serv/workflows.go\` next to the existing \`defaultWorkflowScriptTimeout\` constant.

## Reproducer

\`\`\`bash
curl -s -w '\nhttp=%{http_code} time=%{time_total}\n' \\
  -X POST http://localhost:8080/api/v1/mcp \\
  -H 'Content-Type: application/json' \\
  -H 'Accept: application/json, text/event-stream' \\
  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"execute_workflow\",\"arguments\":{\"name\":\"<slow-workflow>\"}}}' \\
  --max-time 60
\`\`\`

**Before:** \`http=000 time=60.000\` (server killed connection at 10s, curl waited until its own \`--max-time\`)
**After:** \`http=200\` with the workflow result

## Test plan

- [x] \`go build ./...\` clean
- [x] Curl reproducer above returns the workflow result instead of timing out
- [x] Verified end-to-end via a downstream LLM agent (ax-crew + Claude / GLM-5) running multi-step MCP workflows that previously dropped at the 10s mark
- [ ] CI tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)