### PR TITLE
fix: CLI setup against SPA-fallback servers + Snowflake JWT keepalive

### DIFF
--- a/cmd/cmd_setup.go
+++ b/cmd/cmd_setup.go
@@ -244,6 +244,13 @@ func startDeviceFlow(ctx context.Context, server string) (*deviceStartResp, bool
 	b, _ := io.ReadAll(resp.Body)
 	switch resp.StatusCode {
 	case http.StatusOK:
+		// When auth_login is disabled the device route isn't registered, but
+		// the SPA fallback handler may serve the GraphQL editor's index.html
+		// at this path — a 200 with text/html. Treat any non-JSON 200 as
+		// "no built-in login" rather than failing to decode.
+		if !isJSONResponse(resp, b) {
+			return nil, false, nil
+		}
 		var ds deviceStartResp
 		if err := json.Unmarshal(b, &ds); err != nil {
 			return nil, false, fmt.Errorf("decode response: %w", err)
@@ -257,6 +264,24 @@ func startDeviceFlow(ctx context.Context, server string) (*deviceStartResp, bool
 	default:
 		return nil, false, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
 	}
+}
+
+// isJSONResponse reports whether the response is JSON, by Content-Type or
+// by sniffing the first non-whitespace byte of the body. The body sniff
+// catches misconfigured servers/proxies that omit or lie about Content-Type.
+func isJSONResponse(resp *http.Response, body []byte) bool {
+	ct := resp.Header.Get("Content-Type")
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	if strings.EqualFold(strings.TrimSpace(ct), "application/json") {
+		return true
+	}
+	trimmed := bytes.TrimLeft(body, " \t\r\n")
+	if len(trimmed) == 0 {
+		return false
+	}
+	return trimmed[0] == '{' || trimmed[0] == '['
 }
 
 // pollDeviceToken polls once. Returns (token, true, nil) when the user has

--- a/cmd/cmd_setup_test.go
+++ b/cmd/cmd_setup_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// When auth_login is disabled, the device endpoint isn't registered. Some
+// servers serve the SPA index.html via a catch-all fallback, returning
+// HTTP 200 with text/html. startDeviceFlow must treat that as "no built-in
+// login" (hasAuth=false, err=nil), not as a JSON decode error.
+func TestStartDeviceFlow_SPAFallbackHTMLAsNoAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!DOCTYPE html><html><body>SPA</body></html>"))
+	}))
+	defer srv.Close()
+
+	ds, hasAuth, err := startDeviceFlow(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if hasAuth {
+		t.Fatalf("expected hasAuth=false for HTML fallback, got true")
+	}
+	if ds != nil {
+		t.Fatalf("expected nil deviceStartResp, got %+v", ds)
+	}
+}
+
+func TestStartDeviceFlow_404AsNoAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ds, hasAuth, err := startDeviceFlow(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if hasAuth {
+		t.Fatalf("expected hasAuth=false for 404, got true")
+	}
+	if ds != nil {
+		t.Fatalf("expected nil deviceStartResp, got %+v", ds)
+	}
+}
+
+func TestStartDeviceFlow_JSONOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"device_code":"dc","user_code":"UC","verification_uri":"http://x/v","interval":5,"expires_in":600}`))
+	}))
+	defer srv.Close()
+
+	ds, hasAuth, err := startDeviceFlow(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if !hasAuth {
+		t.Fatalf("expected hasAuth=true for JSON 200, got false")
+	}
+	if ds == nil || ds.DeviceCode != "dc" || ds.UserCode != "UC" {
+		t.Fatalf("unexpected deviceStartResp: %+v", ds)
+	}
+}
+
+func TestIsJSONResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		ct   string
+		body string
+		want bool
+	}{
+		{"json content-type", "application/json", "{}", true},
+		{"json with charset", "application/json; charset=utf-8", "{}", true},
+		{"html content-type", "text/html; charset=utf-8", "<html></html>", false},
+		{"empty content-type, json body", "", "  {\"a\":1}", true},
+		{"empty content-type, array body", "", "[1,2]", true},
+		{"empty content-type, html body", "", "<!DOCTYPE html>", false},
+		{"empty content-type, empty body", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			if tc.ct != "" {
+				resp.Header.Set("Content-Type", tc.ct)
+			}
+			if got := isJSONResponse(resp, []byte(tc.body)); got != tc.want {
+				t.Fatalf("isJSONResponse(%q, %q) = %v, want %v", tc.ct, tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/serv/db.go
+++ b/serv/db.go
@@ -477,11 +477,26 @@ func initSnowflake(conf *Config, openDB, useTelemetry bool, fs core.FS) (*dbConf
 		return nil, fmt.Errorf("snowflake: %w", err)
 	}
 
-	cfg.Authenticator = gosnowflake.AuthTypeJwt
-	cfg.PrivateKey = privKey
+	applySnowflakeJWT(cfg, privKey)
 
 	connector := gosnowflake.NewConnector(gosnowflake.SnowflakeDriver{}, *cfg)
 	return &dbConf{connector: connector}, nil
+}
+
+// applySnowflakeJWT configures a gosnowflake.Config for key pair (JWT) auth.
+// Sets ClientSessionKeepAlive so idle pooled connections don't hit the ~4h
+// master-token expiry — without it, the next query after expiry returns
+// "390114: Authentication token has expired" instead of transparently
+// re-signing a JWT. The keepalive flag is documented in gosnowflake as the
+// session parameter "client_session_keep_alive" (map[string]*string).
+func applySnowflakeJWT(cfg *gosnowflake.Config, privKey *rsa.PrivateKey) {
+	cfg.Authenticator = gosnowflake.AuthTypeJwt
+	cfg.PrivateKey = privKey
+	if cfg.Params == nil {
+		cfg.Params = map[string]*string{}
+	}
+	keepAlive := "true"
+	cfg.Params["client_session_keep_alive"] = &keepAlive
 }
 
 // parseSnowflakeDSN parses a Snowflake connection string into a gosnowflake.Config

--- a/serv/db_test.go
+++ b/serv/db_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/dosco/graphjin/core/v3"
+	"github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -339,4 +340,47 @@ func TestInitSnowflake_InvalidKeyPEM(t *testing.T) {
 	_, err := initSnowflake(conf, true, false, core.NewOsFS(""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no PEM block found")
+}
+
+// applySnowflakeJWT must enable client_session_keep_alive so idle pooled
+// connections don't hit Snowflake's master-token expiry and start returning
+// "390114: Authentication token has expired".
+func TestApplySnowflakeJWT_EnablesKeepAlive(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	cfg := &gosnowflake.Config{
+		User:    "u",
+		Account: "a",
+	}
+	applySnowflakeJWT(cfg, key)
+
+	assert.Equal(t, gosnowflake.AuthTypeJwt, cfg.Authenticator)
+	assert.Same(t, key, cfg.PrivateKey)
+
+	require.NotNil(t, cfg.Params, "Params map must be initialized")
+	v, ok := cfg.Params["client_session_keep_alive"]
+	require.True(t, ok, "client_session_keep_alive must be set")
+	require.NotNil(t, v)
+	assert.Equal(t, "true", *v)
+}
+
+// Pre-populated Params from DSN parsing must survive applySnowflakeJWT.
+func TestApplySnowflakeJWT_PreservesExistingParams(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	existing := "myrole"
+	cfg := &gosnowflake.Config{
+		Params: map[string]*string{"role": &existing},
+	}
+	applySnowflakeJWT(cfg, key)
+
+	if v, ok := cfg.Params["role"]; !ok || v == nil || *v != "myrole" {
+		t.Fatalf("existing Params entry was clobbered: %+v", cfg.Params)
+	}
+	v, ok := cfg.Params["client_session_keep_alive"]
+	require.True(t, ok)
+	require.NotNil(t, v)
+	assert.Equal(t, "true", *v)
 }


### PR DESCRIPTION
Two related-but-independent fixes the same branch picked up while reproducing this against a real GraphJin server with disabled login + Snowflake keypair auth.

## 1. CLI: `setup` against servers with `auth_login` disabled (commit `bf6d00a`)
**Symptom:** `graphjin cli setup <url>` exits with `decode response: invalid character '<' looking for beginning of value`.

**Cause:** `startDeviceFlow` only treated 404/405 on `/api/v1/auth/device` as "no built-in login". Servers with `auth_login` disabled but a SPA fallback handler return HTTP 200 + `text/html` (the GraphQL editor's `index.html`) at that path, which slipped through the JSON decoder.

**Fix:** sniff the response (`Content-Type`, falling back to the first non-whitespace body byte). Any non-JSON 200 is treated the same as 404/405 — the URL is saved with an empty token.

## 2. Snowflake: 390114 token-expiry on idle pooled connections (commit `9b75693`)
**Symptom:** With keypair JWT auth correctly configured, after a few hours of idleness every query (including `check_health`'s ping and `list_databases`) returns:
```
ping failed: 390114: Authentication token has expired.  The user must authenticate again.
```
Connections stay in the pool — `pool_stats.idle: 2, open_connections: 2` — but every query fails until the server restarts.

**Cause:** gosnowflake doesn't transparently re-sign a fresh JWT when the master/session token expires (~4h default). Without a keepalive heartbeat, idle connections rot.

**Fix:** set `client_session_keep_alive=true` on the gosnowflake `Config` (via `cfg.Params`, since v1.19.0 reads it as a session parameter, not a struct field). Extracted `applySnowflakeJWT(cfg, key)` so the JWT setup is testable without standing up a real Snowflake.

## Test plan
- [x] `go test ./cmd/ ./serv/ -count=1` — both suites green
- [x] New tests:
  - `TestStartDeviceFlow_SPAFallbackHTMLAsNoAuth` — HTTP 200 + `text/html` → `hasAuth=false`, no error
  - `TestStartDeviceFlow_404AsNoAuth` — regression guard for the existing 404 path
  - `TestStartDeviceFlow_JSONOK` — happy path still parses
  - `TestIsJSONResponse` — Content-Type and body-sniff matrix
  - `TestApplySnowflakeJWT_EnablesKeepAlive` — confirms `client_session_keep_alive=true` ends up in `cfg.Params`
  - `TestApplySnowflakeJWT_PreservesExistingParams` — ensures DSN-parsed params survive
- [x] Manually reproduced (1) against a live GraphJin server with `auth_login` disabled + SPA fallback — `setup` now writes `client.json` with empty token instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)