### PR TITLE
docs(mcp): add get_table_sample to discovery sequence in server instructions

### DIFF
--- a/serv/mcp_instructions.go
+++ b/serv/mcp_instructions.go
@@ -8,8 +8,12 @@ const serverInstructions = `GraphJin is a GraphQL-to-SQL compiler. You query dat
 2. Call tool list_tables — find relevant tables.
 3. Use find_path or explore_relationships to understand how tables connect — do NOT guess join paths.
 4. Use describe_table for column details on the specific tables you need.
-5. Check list_workflows for an existing workflow that already answers the question.
-6. If no existing workflow fits, write a new workflow using execute_workflow.
+5. Use get_table_sample on any table whose VALUES matter — to see real column
+   values (status strings, enum labels, naming conventions like "leadid" vs
+   "lead_id"), distributions, and a few sample rows. Call this BEFORE writing
+   filters that depend on specific string values.
+6. Check list_workflows for an existing workflow that already answers the question.
+7. If no existing workflow fits, write a new workflow using execute_workflow.
 
 ## ALWAYS use workflows
 


### PR DESCRIPTION
## Summary

- Adds a step to the MCP server's `Before answering any data question` checklist (sent in every `initialize` response) directing agents to call `get_table_sample` whenever **specific column values matter** — status strings, enum labels, naming conventions like `leadid` vs `lead_id`, distributions, sample rows.
- Goal: stop agents from writing `where:` clauses against guessed column values when sample data is one tool call away.

## Why

`get_table_sample` is registered (`serv/mcp_schema.go:116-122`) and described as *"the only schema discovery tool that runs data queries; call it only when row counts, value distributions, numeric/date stats, or sample rows are needed"* — but the server instructions never told agents to use it. So agents that follow the documented checklist (`get_query_syntax → list_tables → find_path/explore_relationships → describe_table → list_workflows → execute_workflow`) skip past it and end up brute-forcing column names with `execute_graphql` when value-specific filters are needed.

Observed in a Marketo schema session: an agent asked for "histogram of job titles of paid webinar attendees" attempted ~10 `execute_graphql` calls guessing column names (`status`, `step`, `newstatus`, `newstatusid`, `oldstatus`, `id`, ...) before stalling — every guess returned `field 'X' is not a column or a function`. A single `get_table_sample` call would have shown the actual schema.

## Change

```diff
 4. Use describe_table for column details on the specific tables you need.
-5. Check list_workflows for an existing workflow that already answers the question.
-6. If no existing workflow fits, write a new workflow using execute_workflow.
+5. Use get_table_sample on any table whose VALUES matter — to see real column
+    values (status strings, enum labels, naming conventions like "leadid" vs
+    "lead_id"), distributions, and a few sample rows. Call this BEFORE writing
+    filters that depend on specific string values.
+6. Check list_workflows for an existing workflow that already answers the question.
+7. If no existing workflow fits, write a new workflow using execute_workflow.
```

Single file, +6 / -2. No code paths touched — instruction string only. Picked up by every MCP client on next `initialize`.

## Test plan

- [x] `go build ./serv/...` clean
- [ ] Connect Claude Desktop to a server running this build, confirm new step appears in the `initialize` response's `instructions` field
- [ ] Re-run a value-dependent query (e.g. histogram by job title for a filtered subset) and verify the agent calls `get_table_sample` before authoring the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)