### PR TITLE
MCP/CLI: actionable errors, query patterns, FK disambiguation, compiler fixes

### DIFF
--- a/cmd/mcp_parity_test.go
+++ b/cmd/mcp_parity_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/dosco/graphjin/serv/v3"
+)
+
+// TestMCPCLIParity enforces the hard rule: every MCP tool the server may
+// expose must have a corresponding CLI subcommand with the exact same
+// name. The CLI is the only path users have without an MCP-aware client,
+// so drift here silently strands a capability for those users.
+//
+// If this test fails after adding/removing/renaming an MCP tool, the
+// fix is in cmd/mcp_tools.go::mcpParityToolCmds (which builds from
+// serv.MCPAllToolNames) — not by editing the test.
+func TestMCPCLIParity(t *testing.T) {
+	serverTools := append([]string(nil), serv.MCPAllToolNames()...)
+	cliTools := append([]string(nil), mcpExactToolNames()...)
+	sort.Strings(serverTools)
+	sort.Strings(cliTools)
+
+	serverSet := make(map[string]bool, len(serverTools))
+	for _, n := range serverTools {
+		serverSet[n] = true
+	}
+	cliSet := make(map[string]bool, len(cliTools))
+	for _, n := range cliTools {
+		cliSet[n] = true
+	}
+
+	var missingFromCLI []string
+	for _, n := range serverTools {
+		if !cliSet[n] {
+			missingFromCLI = append(missingFromCLI, n)
+		}
+	}
+	var extraInCLI []string
+	for _, n := range cliTools {
+		if !serverSet[n] {
+			extraInCLI = append(extraInCLI, n)
+		}
+	}
+
+	if len(missingFromCLI) > 0 {
+		t.Errorf("MCP tools missing CLI parity command: %v", missingFromCLI)
+	}
+	if len(extraInCLI) > 0 {
+		t.Errorf("CLI commands without a matching MCP tool: %v", extraInCLI)
+	}
+
+	if t.Failed() {
+		t.Logf("server (%d): %v", len(serverTools), serverTools)
+		t.Logf("cli    (%d): %v", len(cliTools), cliTools)
+	}
+}
+
+// TestMCPCLIResourceParity enforces the same rule for static MCP
+// resources (query_syntax, mutation_syntax, workflow_guide, etc.).
+// Surfaced via mcpParityResourceCmds in cmd_cli.go.
+func TestMCPCLIResourceParity(t *testing.T) {
+	serverResources := serv.MCPCLIResources()
+	cliResourceCmds := mcpParityResourceCmds()
+
+	if len(cliResourceCmds) != len(serverResources) {
+		t.Fatalf("resource parity drift: %d server-side, %d cli-side", len(serverResources), len(cliResourceCmds))
+	}
+
+	cliNames := make(map[string]bool, len(cliResourceCmds))
+	for _, c := range cliResourceCmds {
+		cliNames[c.Use] = true
+	}
+	for _, r := range serverResources {
+		if !cliNames[r.Command] {
+			t.Errorf("MCP resource %q (%s) has no CLI command", r.Command, r.URI)
+		}
+	}
+}

--- a/core/api.go
+++ b/core/api.go
@@ -879,8 +879,10 @@ type TableSchema struct {
 	PrimaryKey      string       `json:"primary_key,omitempty"`
 	PrimaryKeys     []string     `json:"primary_keys,omitempty"`
 	FullTextColumns []string     `json:"full_text_columns,omitempty"`
-	Columns         []ColumnInfo `json:"columns"`
-	Relationships   struct {
+	PartitionKey         string       `json:"partition_key,omitempty"`
+	ImplicitPartitionKey string       `json:"implicit_partition_key,omitempty"`
+	Columns              []ColumnInfo `json:"columns"`
+	Relationships        struct {
 		Outgoing []RelationInfo `json:"outgoing"` // Tables this table references
 		Incoming []RelationInfo `json:"incoming"` // Tables that reference this table
 	} `json:"relationships"`
@@ -1181,6 +1183,9 @@ func (gj *graphjinEngine) buildTableSchemaWithSchema(dbSchema *sdata.DBSchema, d
 	if len(t.PrimaryCols) > 1 {
 		schema.PrimaryKeys = t.PKColNames()
 	}
+
+	schema.PartitionKey = t.PartitionKey
+	schema.ImplicitPartitionKey = t.ImplicitPartitionKey
 
 	// FullText columns
 	for _, ft := range t.FullText {

--- a/core/internal/psql/psql_test.go
+++ b/core/internal/psql/psql_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/dosco/graphjin/core/v3/internal/psql"
@@ -198,4 +199,85 @@ func _compileGQLToPSQL(t *testing.T, gql string, vars json.RawMessage, role stri
 	}
 
 	return nil
+}
+
+// TestCompositeFK_ThroughColumn_EmitsFullJoinCondition is the end-to-end
+// verification for P5: Stage 1b made @through(column:) match any column
+// of a composite FK via ExtraPairs. This test confirms the SQL emitter
+// then uses ALL composite columns in the join condition (not just the
+// primary). If only the primary column appears in the emitted JOIN, the
+// composite FK isn't actually being honored downstream — which would be
+// a real bug to fix here.
+//
+// Schema (GetTestCompositeFKSchema):
+//   enrollment.(term_id, course_id) ─ composite FK ─→ course_offering.(term_id, course_id)
+//
+// The query names course_id — the SECOND composite column, which lives
+// in ExtraPairs not L/R. Pre-Stage-1b this returned "relationship not
+// found".
+func TestCompositeFK_ThroughColumn_EmitsFullJoinCondition(t *testing.T) {
+	schema, err := sdata.GetTestCompositeFKSchema()
+	if err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+
+	qc, err := qcode.NewCompiler(schema, qcode.Config{DBSchema: schema.DBSchema()})
+	if err != nil {
+		t.Fatalf("qcode compiler: %v", err)
+	}
+	if err := qc.AddRole("user", "public", "enrollment", qcode.TRConfig{
+		Query: qcode.QueryConfig{Columns: []string{"id", "term_id", "course_id", "student_name"}},
+	}); err != nil {
+		t.Fatalf("add enrollment role: %v", err)
+	}
+	if err := qc.AddRole("user", "public", "course_offering", qcode.TRConfig{
+		Query: qcode.QueryConfig{Columns: []string{"term_id", "course_id", "title"}},
+	}); err != nil {
+		t.Fatalf("add course_offering role: %v", err)
+	}
+
+	pc := psql.NewCompiler(psql.Config{})
+
+	gql := `query {
+		enrollment {
+			id
+			course_offering @through(column: "course_id") {
+				term_id
+				course_id
+				title
+			}
+		}
+	}`
+
+	qcRes, err := qc.Compile([]byte(gql), nil, "user", "")
+	if err != nil {
+		t.Fatalf("qcode compile: %v", err)
+	}
+
+	_, sqlBytes, err := pc.CompileEx(qcRes)
+	if err != nil {
+		t.Fatalf("psql compile: %v", err)
+	}
+	sql := string(sqlBytes)
+
+	// Both composite columns must appear in the emitted join condition,
+	// not just somewhere in the SELECT. Look for term_id AND course_id
+	// after the WHERE keyword that follows the LATERAL course_offering
+	// subquery — that's where the join predicate lives.
+	loIdx := strings.Index(strings.ToLower(sql), "course_offering")
+	if loIdx < 0 {
+		t.Fatalf("emitted SQL missing course_offering join:\n%s", sql)
+	}
+	whereIdx := strings.Index(strings.ToLower(sql[loIdx:]), "where")
+	if whereIdx < 0 {
+		t.Fatalf("emitted SQL has course_offering but no WHERE clause for the join:\n%s", sql)
+	}
+	joinClause := sql[loIdx+whereIdx:]
+	if !strings.Contains(joinClause, "term_id") {
+		t.Errorf("join clause missing term_id (primary composite column).\nfull SQL:\n%s\njoin clause:\n%s", sql, joinClause)
+	}
+	if !strings.Contains(joinClause, "course_id") {
+		t.Errorf("join clause missing course_id (ExtraPairs composite column).\nfull SQL:\n%s\njoin clause:\n%s", sql, joinClause)
+	}
+	t.Logf("emitted SQL (composite-FK join verified):\n%s", sql)
 }

--- a/core/internal/qcode/err.go
+++ b/core/internal/qcode/err.go
@@ -1,12 +1,26 @@
 package qcode
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/dosco/graphjin/core/v3/internal/sdata"
 )
 
 func graphError(err error, from, to, through string) error {
+	var ambig *sdata.AmbiguousPathError
+	if errors.As(err, &ambig) {
+		cols := make([]string, len(ambig.Candidates))
+		snippets := make([]string, len(ambig.Candidates))
+		for i, c := range ambig.Candidates {
+			cols[i] = c.Column
+			snippets[i] = fmt.Sprintf(`@through(column: %q)`, c.Column)
+		}
+		return fmt.Errorf(
+			"ambiguous relationship %s -> %s: multiple foreign keys (%s). Disambiguate by adding %s on the nested selection",
+			from, to, strings.Join(cols, ", "), strings.Join(snippets, " or "))
+	}
 	switch err {
 	case sdata.ErrFromEdgeNotFound:
 		return fmt.Errorf("table not found: %s", from)

--- a/core/internal/qcode/qcode.go
+++ b/core/internal/qcode/qcode.go
@@ -1041,10 +1041,17 @@ func (co *Compiler) FindPath(from, to, through string) ([]sdata.TPath, error) {
 		return path, nil
 	}
 
-	// Graph traversal failed — check cross-database FK metadata.
-	// Cross-DB target tables are not in the graph, so FindPath won't find them.
-	if tp, ok := co.s.FindCrossDBPath(from, to); ok {
-		return []sdata.TPath{tp}, nil
+	// Cross-DB fallback: only fire when the in-graph relationship is
+	// genuinely missing (ErrPathNotFound or ErrFromEdgeNotFound /
+	// ErrToEdgeNotFound — the table isn't in this database's graph).
+	// Other errors — most importantly *AmbiguousPathError — must propagate
+	// unchanged, otherwise the cross-DB short-circuit silently hides
+	// legitimate compile-time signals from the caller.
+	switch err {
+	case sdata.ErrPathNotFound, sdata.ErrFromEdgeNotFound, sdata.ErrToEdgeNotFound:
+		if tp, ok := co.s.FindCrossDBPath(from, to); ok {
+			return []sdata.TPath{tp}, nil
+		}
 	}
 
 	return nil, err

--- a/core/internal/qcode/qcode.go
+++ b/core/internal/qcode/qcode.go
@@ -1337,7 +1337,7 @@ func (co *Compiler) enforcePartitionFilterOLAP(sel *Select) {
 			return
 		}
 		sel.PartitionFilterRequired = fmt.Sprintf(
-			"table %q requires a filter on partition column %q (e.g., { %s: { gt: \"2026-01-01\" } })",
+			"table %q requires a filter on partition column %q. Add one of: where: { %s: { gte: \"<date>\" } }; or pass unrestricted: true to override.",
 			sel.Ti.Name, sel.Ti.PartitionKey, sel.Ti.PartitionKey)
 		return
 	}
@@ -1347,7 +1347,7 @@ func (co *Compiler) enforcePartitionFilterOLAP(sel *Select) {
 			return
 		}
 		sel.PartitionFilterRequired = fmt.Sprintf(
-			"table %q requires a filter on temporal column %q (e.g., { %s: { gt: \"2026-01-01\" } }); pass `unrestricted: true` to override",
+			"table %q requires a filter on temporal column %q. Add one of: where: { %s: { gte: \"<date>\" } }; or pass unrestricted: true to override.",
 			sel.Ti.Name, sel.Ti.ImplicitPartitionKey, sel.Ti.ImplicitPartitionKey)
 	}
 }

--- a/core/internal/qcode/qcode.go
+++ b/core/internal/qcode/qcode.go
@@ -706,6 +706,70 @@ func (co *Compiler) compileQuery(qc *QCode, op *graph.Operation, role string) er
 		return errors.New("invalid query: no selectors found")
 	}
 
+	if err := validateGroupByJoinShape(qc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateGroupByJoinShape rejects queries where a parent selection has both
+// a `distinct:` clause and an aggregate, AND nests a child whose join column
+// on the parent side is not in `distinct`. The compiler emits a GROUP BY CTE
+// that collapses the un-distinct'd FK column, leaving the nested lateral
+// join referencing a column the CTE no longer projects ("salesorderdetail_0
+// .salesorderid does not exist" / "purchases_0.customer_id does not exist").
+//
+// Semantically the query is ambiguous — many join-key values per group —
+// so silent SQL emission would be wrong even if it executed. The right
+// shape for "metric by dimension" is to root at the dimension table.
+func validateGroupByJoinShape(qc *QCode) error {
+	for i := range qc.Selects {
+		child := &qc.Selects[i]
+		if child.ParentID == -1 {
+			continue
+		}
+		switch child.Rel.Type {
+		case sdata.RelRemote, sdata.RelDatabaseJoin, sdata.RelNone, sdata.RelPolymorphic:
+			continue
+		}
+		parent := &qc.Selects[child.ParentID]
+		if !parent.GroupCols || len(parent.DistinctOn) == 0 {
+			continue
+		}
+
+		// The column on the parent side that the nested join uses.
+		// For single-hop nesting it lives on sel.Rel; for multi-hop, the
+		// hop touching the parent is Joins[0].
+		var joinCol string
+		if len(child.Joins) > 0 {
+			joinCol = child.Joins[0].Rel.Right.Col.Name
+		} else {
+			joinCol = child.Rel.Right.Col.Name
+		}
+		if joinCol == "" {
+			continue
+		}
+
+		inDistinct := false
+		for _, dc := range parent.DistinctOn {
+			if strings.EqualFold(dc.Name, joinCol) {
+				inDistinct = true
+				break
+			}
+		}
+		if inDistinct {
+			continue
+		}
+
+		distinctNames := make([]string, len(parent.DistinctOn))
+		for j, dc := range parent.DistinctOn {
+			distinctNames[j] = dc.Name
+		}
+		return fmt.Errorf(
+			"nested selection '%s' joins through parent column '%s.%s', which is not in distinct: [%s]. The GROUP BY collapses '%s' away, leaving many %s values per group with no defined join. Root the query at the dimension table instead — see get_workflow_guide for the metric-by-dimension pattern.",
+			child.Table, parent.Table, joinCol, strings.Join(distinctNames, ", "), joinCol, joinCol)
+	}
 	return nil
 }
 

--- a/core/internal/sdata/dwg.go
+++ b/core/internal/sdata/dwg.go
@@ -15,6 +15,33 @@ var (
 	ErrThoughNodeNotFound = errors.New("though node not found")
 )
 
+// FKCandidate describes one foreign key option when an A→B relationship
+// has multiple FKs and disambiguation is required.
+type FKCandidate struct {
+	Column           string
+	TargetTable      string
+	TargetColumn     string
+	IsComposite      bool
+	CompositeColumns []string
+}
+
+// AmbiguousPathError is returned when a direct (single-hop) relationship
+// between two tables has multiple distinct foreign keys and the caller did
+// not provide a @through hint to disambiguate.
+type AmbiguousPathError struct {
+	From, To   string
+	Candidates []FKCandidate
+}
+
+func (e *AmbiguousPathError) Error() string {
+	cols := make([]string, len(e.Candidates))
+	for i, c := range e.Candidates {
+		cols[i] = c.Column
+	}
+	return fmt.Sprintf("ambiguous relationship %s -> %s: multiple foreign keys (%s)",
+		e.From, e.To, strings.Join(cols, ", "))
+}
+
 // TEdge represents a table edge for the graph
 type TEdge struct {
 	From, To, Weight int32
@@ -348,6 +375,14 @@ func (s *DBSchema) pickPath(from, to edgeInfo, through string) (res graphResult,
 		if err != nil {
 			return
 		}
+	} else {
+		if cands := s.detectDirectAmbiguity(paths, from); len(cands) > 1 {
+			return res, &AmbiguousPathError{
+				From:       s.tables[from.nodeID].Name,
+				To:         s.tables[to.nodeID].Name,
+				Candidates: cands,
+			}
+		}
 	}
 
 	for _, path := range paths {
@@ -358,6 +393,73 @@ func (s *DBSchema) pickPath(from, to edgeInfo, through string) (res graphResult,
 		}
 	}
 	return res, ErrPathNotFound
+}
+
+// detectDirectAmbiguity returns FK candidates when two tables share multiple
+// distinct foreign keys via a direct (single-hop) edge. Returns nil for
+// multi-hop or unambiguous relationships; multi-hop disambiguation goes
+// through the existing min-weight selection.
+func (s *DBSchema) detectDirectAmbiguity(paths [][]int32, from edgeInfo) []FKCandidate {
+	var direct []int32
+	for _, p := range paths {
+		if len(p) == 2 {
+			direct = p
+			break
+		}
+	}
+	if direct == nil {
+		return nil
+	}
+
+	lines := s.relationshipGraph.GetEdges(direct[0], direct[1])
+	seen := make(map[string]struct{})
+	var cands []FKCandidate
+
+	for _, v := range lines {
+		edge, ok := s.allEdges[v.ID]
+		if !ok {
+			continue
+		}
+		// Skip the reverse half of a self-referential FK: in the recursive
+		// comments→comments case both forward (L=fk, R=pk) and reverse (L=pk,
+		// R=fk) live in the same bucket. The forward edge is the one whose L
+		// column declares FKeyTable.
+		if edge.L.FKeyTable == "" {
+			continue
+		}
+		anchored := false
+		for _, eid := range from.edgeIDs {
+			if eid == v.ID {
+				anchored = true
+				break
+			}
+		}
+		if !anchored {
+			continue
+		}
+		key := edge.L.Name
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		c := FKCandidate{
+			Column:       edge.L.Name,
+			TargetTable:  edge.RT.Name,
+			TargetColumn: edge.R.Name,
+		}
+		if len(edge.ExtraPairs) > 0 {
+			c.IsComposite = true
+			cols := make([]string, 0, len(edge.ExtraPairs)+1)
+			cols = append(cols, edge.L.Name)
+			for _, p := range edge.ExtraPairs {
+				cols = append(cols, p.L.Name)
+			}
+			c.CompositeColumns = cols
+		}
+		cands = append(cands, c)
+	}
+	return cands
 }
 
 // pickEdges picks edges between two tables
@@ -526,7 +628,18 @@ func (s *DBSchema) filterLinesByColumn(lines []util.Edge, col string) []util.Edg
 		if !ok {
 			continue
 		}
-		if strings.EqualFold(edge.L.Name, col) || strings.EqualFold(edge.R.Name, col) {
+		match := strings.EqualFold(edge.L.Name, col) || strings.EqualFold(edge.R.Name, col)
+		if !match {
+			// Composite FKs: the first column lives in L/R, the rest in ExtraPairs.
+			// Naming any column of the composite is enough to identify it.
+			for _, p := range edge.ExtraPairs {
+				if strings.EqualFold(p.L.Name, col) || strings.EqualFold(p.R.Name, col) {
+					match = true
+					break
+				}
+			}
+		}
+		if match {
 			out = append(out, v)
 		}
 	}

--- a/core/internal/sdata/dwg.go
+++ b/core/internal/sdata/dwg.go
@@ -412,7 +412,18 @@ func (s *DBSchema) detectDirectAmbiguity(paths [][]int32, from edgeInfo) []FKCan
 	}
 
 	lines := s.relationshipGraph.GetEdges(direct[0], direct[1])
-	seen := make(map[string]struct{})
+
+	// Dedup forward+reverse halves of the same FK constraint without
+	// silencing genuine multi-FK ambiguity. Two edges in the same bucket
+	// are "the same FK" iff they're each other's opposites — true only
+	// for self-referential FKs (recursive comments → comments). For
+	// non-recursive multi-FK (orders → users with two distinct FKs), the
+	// edges in either bucket are NOT each other's opposites — their
+	// OppIDs reference edges in the OTHER bucket. We track edge IDs as
+	// we iterate; subsequent edges that name an already-seen OppID are
+	// the recursive-pair we want to drop.
+	bucketSeen := make(map[int32]bool)
+	colSeen := make(map[string]struct{})
 	var cands []FKCandidate
 
 	for _, v := range lines {
@@ -420,40 +431,71 @@ func (s *DBSchema) detectDirectAmbiguity(paths [][]int32, from edgeInfo) []FKCan
 		if !ok {
 			continue
 		}
-		// Skip the reverse half of a self-referential FK: in the recursive
-		// comments→comments case both forward (L=fk, R=pk) and reverse (L=pk,
-		// R=fk) live in the same bucket. The forward edge is the one whose L
-		// column declares FKeyTable.
-		if edge.L.FKeyTable == "" {
+		// Self-referential dedup: if this edge's OppID is already in the
+		// bucket, we've already counted its constraint.
+		if v.OppID != -1 && bucketSeen[v.OppID] {
 			continue
 		}
-		anchored := false
-		for _, eid := range from.edgeIDs {
-			if eid == v.ID {
-				anchored = true
-				break
+		bucketSeen[v.ID] = true
+
+		// Anchor: if the caller's edgeInfo lists specific edges, only
+		// count those. Empty edgeIDs means "no anchor filter" (e.g. when
+		// pickPath was called from FindPath against a name index that
+		// matched the bucket directly).
+		if len(from.edgeIDs) > 0 {
+			anchored := false
+			for _, eid := range from.edgeIDs {
+				if eid == v.ID || eid == v.OppID {
+					anchored = true
+					break
+				}
+			}
+			if !anchored {
+				continue
 			}
 		}
-		if !anchored {
+
+		// Resolve the FK side of the edge: for forward edges L is the
+		// FK column; for reverse edges R is the FK column. The FK column
+		// is the one whose owning DBColumn declares FKeyTable.
+		var fkCol DBColumn
+		var fkTable, refCol string
+		switch {
+		case edge.L.FKeyTable != "":
+			fkCol = edge.L
+			fkTable = edge.LT.Name
+			refCol = edge.R.Name
+		case edge.R.FKeyTable != "":
+			fkCol = edge.R
+			fkTable = edge.RT.Name
+			refCol = edge.L.Name
+		default:
+			// Neither side declares an FK — skip (ambiguous edges from
+			// non-FK relationships like polymorphic / virtual tables).
 			continue
 		}
-		key := edge.L.Name
-		if _, dup := seen[key]; dup {
+		_ = fkTable
+
+		if _, dup := colSeen[fkCol.Name]; dup {
 			continue
 		}
-		seen[key] = struct{}{}
+		colSeen[fkCol.Name] = struct{}{}
 
 		c := FKCandidate{
-			Column:       edge.L.Name,
-			TargetTable:  edge.RT.Name,
-			TargetColumn: edge.R.Name,
+			Column:       fkCol.Name,
+			TargetTable:  fkCol.FKeyTable,
+			TargetColumn: refCol,
 		}
 		if len(edge.ExtraPairs) > 0 {
 			c.IsComposite = true
 			cols := make([]string, 0, len(edge.ExtraPairs)+1)
-			cols = append(cols, edge.L.Name)
+			cols = append(cols, fkCol.Name)
 			for _, p := range edge.ExtraPairs {
-				cols = append(cols, p.L.Name)
+				if p.L.FKeyTable != "" {
+					cols = append(cols, p.L.Name)
+				} else if p.R.FKeyTable != "" {
+					cols = append(cols, p.R.Name)
+				}
 			}
 			c.CompositeColumns = cols
 		}

--- a/core/internal/sdata/dwg_test.go
+++ b/core/internal/sdata/dwg_test.go
@@ -1,6 +1,8 @@
 package sdata_test
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/dosco/graphjin/core/v3/internal/assert"
@@ -30,5 +32,82 @@ func TestDWG(t *testing.T) {
 		got = paths[1].String()
 		assert.Equals(t, exp, got)
 
+	}
+}
+
+func TestDWG_AmbiguousPath(t *testing.T) {
+	s, err := sdata.GetTestMultiFKSchema()
+	assert.NoErrorFatal(t, err)
+
+	_, err = s.FindPath("orders", "users", "")
+	if err == nil {
+		t.Fatal("expected AmbiguousPathError when orders has two FKs to users")
+	}
+
+	var ambig *sdata.AmbiguousPathError
+	if !errors.As(err, &ambig) {
+		t.Fatalf("expected *AmbiguousPathError, got %T: %v", err, err)
+	}
+
+	if len(ambig.Candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d: %+v", len(ambig.Candidates), ambig.Candidates)
+	}
+
+	cols := map[string]bool{}
+	for _, c := range ambig.Candidates {
+		cols[c.Column] = true
+	}
+	if !cols["customer_id"] || !cols["salesperson_id"] {
+		t.Fatalf("expected candidates customer_id + salesperson_id, got %+v", ambig.Candidates)
+	}
+
+	if !strings.Contains(ambig.Error(), "ambiguous relationship") {
+		t.Fatalf("error message missing 'ambiguous relationship' marker: %s", ambig.Error())
+	}
+}
+
+func TestDWG_CompositeFK_ColumnHintMatchesExtraPair(t *testing.T) {
+	s, err := sdata.GetTestCompositeFKSchema()
+	assert.NoErrorFatal(t, err)
+
+	// First composite column: lives in L/R on the edge.
+	paths, err := s.FindPathByColumn("enrollment", "course_offering", "term_id")
+	assert.NoErrorFatal(t, err)
+	if len(paths) == 0 {
+		t.Fatal("expected non-empty path for term_id (primary composite column)")
+	}
+	if len(paths[0].ExtraPairs) == 0 {
+		t.Fatalf("expected composite ExtraPairs on the resolved edge, got %+v", paths[0])
+	}
+
+	// Second composite column: lives only in ExtraPairs. Pre-fix this returned
+	// ErrPathNotFound because filterLinesByColumn ignored ExtraPairs.
+	paths, err = s.FindPathByColumn("enrollment", "course_offering", "course_id")
+	assert.NoErrorFatal(t, err)
+	if len(paths) == 0 {
+		t.Fatal("expected non-empty path for course_id (non-primary composite column)")
+	}
+	if len(paths[0].ExtraPairs) == 0 {
+		t.Fatalf("composite ExtraPairs missing on edge resolved via course_id: %+v", paths[0])
+	}
+}
+
+func TestDWG_AmbiguousPath_DisambiguatedByColumn(t *testing.T) {
+	s, err := sdata.GetTestMultiFKSchema()
+	assert.NoErrorFatal(t, err)
+
+	paths, err := s.FindPathByColumn("orders", "users", "customer_id")
+	assert.NoErrorFatal(t, err)
+	if len(paths) == 0 {
+		t.Fatal("expected non-empty path with column hint")
+	}
+	if !strings.EqualFold(paths[0].LC.Name, "customer_id") {
+		t.Fatalf("expected path to use customer_id, got %s", paths[0].LC.Name)
+	}
+
+	paths, err = s.FindPathByColumn("orders", "users", "salesperson_id")
+	assert.NoErrorFatal(t, err)
+	if !strings.EqualFold(paths[0].LC.Name, "salesperson_id") {
+		t.Fatalf("expected path to use salesperson_id, got %s", paths[0].LC.Name)
 	}
 }

--- a/core/internal/sdata/test_dbinfo.go
+++ b/core/internal/sdata/test_dbinfo.go
@@ -226,3 +226,79 @@ func GetTestSnowflakeDBInfo() *DBInfo {
 func GetTestSnowflakeSchema() (*DBSchema, error) {
 	return NewDBSchema(GetTestSnowflakeDBInfo(), nil)
 }
+
+// GetTestMultiFKDBInfo returns a DBInfo where the `orders` table has two
+// distinct foreign keys to `users` (customer_id, salesperson_id). Used to
+// exercise ambiguous-path detection.
+func GetTestMultiFKDBInfo() *DBInfo {
+	columns := [][]DBColumn{
+		{
+			{Schema: "public", Table: "users", Name: "id", Type: "bigint", NotNull: true, PrimaryKey: true, UniqueKey: true},
+			{Schema: "public", Table: "users", Name: "name", Type: "character varying", NotNull: true},
+		},
+		{
+			{Schema: "public", Table: "orders", Name: "id", Type: "bigint", NotNull: true, PrimaryKey: true, UniqueKey: true},
+			{Schema: "public", Table: "orders", Name: "customer_id", Type: "bigint", FKeySchema: "public", FKeyTable: "users", FKeyCol: "id"},
+			{Schema: "public", Table: "orders", Name: "salesperson_id", Type: "bigint", FKeySchema: "public", FKeyTable: "users", FKeyCol: "id"},
+			{Schema: "public", Table: "orders", Name: "amount", Type: "numeric(10,2)"},
+		},
+	}
+
+	var cols []DBColumn
+	for _, colset := range columns {
+		cols = append(cols, colset...)
+	}
+
+	di := NewDBInfo("postgres", 140000, "public", "db", cols, nil, nil)
+	return di
+}
+
+// GetTestMultiFKSchema returns a DBSchema with two FKs from orders to users.
+func GetTestMultiFKSchema() (*DBSchema, error) {
+	return NewDBSchema(GetTestMultiFKDBInfo(), nil)
+}
+
+// GetTestCompositeFKDBInfo returns a DBInfo where the `enrollment` table has a
+// composite FK to `course_offering` on (term_id, course_id). Used to verify
+// that @through(column:) matches a non-primary composite-FK column via
+// ExtraPairs (the second column of the composite).
+func GetTestCompositeFKDBInfo() *DBInfo {
+	columns := [][]DBColumn{
+		{
+			{Schema: "public", Table: "course_offering", Name: "term_id", Type: "bigint", NotNull: true, PrimaryKey: true, UniqueKey: true},
+			{Schema: "public", Table: "course_offering", Name: "course_id", Type: "bigint", NotNull: true, PrimaryKey: true, UniqueKey: true},
+			{Schema: "public", Table: "course_offering", Name: "title", Type: "character varying"},
+		},
+		{
+			{Schema: "public", Table: "enrollment", Name: "id", Type: "bigint", NotNull: true, PrimaryKey: true, UniqueKey: true},
+			{Schema: "public", Table: "enrollment", Name: "term_id", Type: "bigint", FKeySchema: "public", FKeyTable: "course_offering", FKeyCol: "term_id"},
+			{Schema: "public", Table: "enrollment", Name: "course_id", Type: "bigint", FKeySchema: "public", FKeyTable: "course_offering", FKeyCol: "course_id"},
+			{Schema: "public", Table: "enrollment", Name: "student_name", Type: "character varying"},
+		},
+	}
+
+	var cols []DBColumn
+	for _, colset := range columns {
+		cols = append(cols, colset...)
+	}
+
+	di := NewDBInfo("postgres", 140000, "public", "db", cols, nil, nil)
+	di.CompositeFKs = []CompositeFKInfo{
+		{
+			Schema:         "public",
+			Table:          "enrollment",
+			ConstraintName: "enrollment_offering_fkey",
+			LocalCols:      []string{"term_id", "course_id"},
+			FKeySchema:     "public",
+			FKeyTable:      "course_offering",
+			FKeyCols:       []string{"term_id", "course_id"},
+		},
+	}
+	return di
+}
+
+// GetTestCompositeFKSchema returns a DBSchema with a composite FK from
+// enrollment to course_offering.
+func GetTestCompositeFKSchema() (*DBSchema, error) {
+	return NewDBSchema(GetTestCompositeFKDBInfo(), nil)
+}

--- a/serv/discovery_sample.go
+++ b/serv/discovery_sample.go
@@ -37,24 +37,33 @@ func (dm *DiscoveryManager) TableSample(ctx context.Context, database, schemaNam
 		if err != nil {
 			return nil, err
 		}
+		outgoing := relationshipRefs(schema.Relationships.Outgoing)
+		analyticsMode := dm.gj != nil && dm.gj.EffectiveAnalyticsMode(resolvedDB)
 		result := &TableSampleResult{
-			Database:       resolvedDB,
-			Schema:         schema.Schema,
-			Table:          schema.Name,
-			Status:         "ready",
-			Stats:          profile,
-			PrimaryKeys:    primaryKeysFromSchema(schema),
-			ForeignKeys:    foreignKeysFromSchema(schema),
-			OutgoingRels:   relationshipRefs(schema.Relationships.Outgoing),
-			IncomingRels:   relationshipRefs(schema.Relationships.Incoming),
-			Indexes:        loadIndexes(ctx, dm.gj, resolvedDB, schema),
-			Aggregations:   aggregationInfoForSchema(schema),
-			ExampleQueries: generateExampleQueries(schema),
+			Database:         resolvedDB,
+			Schema:           schema.Schema,
+			Table:            schema.Name,
+			Status:           "ready",
+			Stats:            profile,
+			PrimaryKeys:      primaryKeysFromSchema(schema),
+			ForeignKeys:      foreignKeysFromSchema(schema),
+			OutgoingRels:     outgoing,
+			IncomingRels:     relationshipRefs(schema.Relationships.Incoming),
+			FKDisambiguation: detectFKDisambiguation(outgoing),
+			Indexes:          loadIndexes(ctx, dm.gj, resolvedDB, schema),
+			Aggregations:     aggregationInfoForSchema(schema),
+			ExampleQueries:   generateExampleQueries(schema),
 			Cost: DiscoveryCost{
 				UsesLiveQueries: true,
 				Scope:           "single_table",
 				Cache:           "miss",
 			},
+		}
+		if analyticsMode {
+			result.AnalyticsModeRules = analyticsModeRules()
+			if isFactShapedTable(schema, profile) {
+				result.AggregationHint = "This looks like a fact table (high row count, multiple outgoing FKs). To aggregate by a dimension, root your query at the dimension table (small side) and nest down to here, not the other way around. distinct: dedupes; it does not bucket."
+			}
 		}
 		dm.profileCache.Store(key, result)
 		return result, nil
@@ -452,6 +461,60 @@ func relationshipRefs(rels []core.RelationInfo) []RelationshipRef {
 			Column: r.ForeignKey,
 			Type:   r.Type,
 		})
+	}
+	return out
+}
+
+// isFactShapedTable returns true when the table looks like an analytics fact
+// table — many outgoing FKs (the dimension keys) and a high approximate row
+// count. Used to attach an aggregation hint.
+func isFactShapedTable(schema *core.TableSchema, profile *TableProfile) bool {
+	if schema == nil {
+		return false
+	}
+	if len(schema.Relationships.Outgoing) < 2 {
+		return false
+	}
+	if profile == nil || profile.RowCountApprox == nil {
+		return false
+	}
+	return *profile.RowCountApprox >= 10000
+}
+
+// detectFKDisambiguation flags multi-FK targets: when this table has more
+// than one outgoing relationship to the same target table, the compiler
+// cannot pick a foreign key without an explicit @through(column:) hint.
+func detectFKDisambiguation(outgoing []RelationshipRef) []FKDisambiguationEntry {
+	groups := map[string][]RelationshipRef{}
+	order := []string{}
+	for _, r := range outgoing {
+		if r.Table == "" || r.Column == "" {
+			continue
+		}
+		if _, seen := groups[r.Table]; !seen {
+			order = append(order, r.Table)
+		}
+		groups[r.Table] = append(groups[r.Table], r)
+	}
+
+	var out []FKDisambiguationEntry
+	for _, target := range order {
+		rels := groups[target]
+		if len(rels) < 2 {
+			continue
+		}
+		entry := FKDisambiguationEntry{
+			Target:     target,
+			Ambiguous:  true,
+			SyntaxHint: `add @through(column: "<fk_column>") on the nested selection`,
+		}
+		for _, r := range rels {
+			entry.Candidates = append(entry.Candidates, FKDisambiguationCandidate{
+				Column:  r.Column,
+				Snippet: fmt.Sprintf(`%s @through(column: %q) { ... }`, target, r.Column),
+			})
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/serv/discovery_sample.go
+++ b/serv/discovery_sample.go
@@ -64,6 +64,7 @@ func (dm *DiscoveryManager) TableSample(ctx context.Context, database, schemaNam
 			if isFactShapedTable(schema, profile) {
 				result.AggregationHint = "This looks like a fact table (high row count, multiple outgoing FKs). To aggregate by a dimension, root your query at the dimension table (small side) and nest down to here, not the other way around. distinct: dedupes; it does not bucket."
 			}
+			result.TemporalFilterWarning = temporalFilterWarning(schema)
 		}
 		dm.profileCache.Store(key, result)
 		return result, nil
@@ -463,6 +464,25 @@ func relationshipRefs(rels []core.RelationInfo) []RelationshipRef {
 		})
 	}
 	return out
+}
+
+// temporalFilterWarning is the per-table paste-ready warning surfaced when analytics_mode requires a date filter.
+func temporalFilterWarning(schema *core.TableSchema) string {
+	if schema == nil {
+		return ""
+	}
+	col := schema.PartitionKey
+	kind := "partition"
+	if col == "" && schema.ImplicitPartitionKey != "" {
+		col = schema.ImplicitPartitionKey
+		kind = "temporal"
+	}
+	if col == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Analytics mode requires a filter on %s column %q. Add one of:\n  where: { %s: { gte: \"<date>\" } }\n  (unrestricted: true)  # full-scan override",
+		kind, col, col)
 }
 
 // isFactShapedTable returns true when the table looks like an analytics fact

--- a/serv/discovery_types.go
+++ b/serv/discovery_types.go
@@ -215,24 +215,22 @@ type TableSampleResult struct {
 	Status   string        `json:"status"`
 	Stats    *TableProfile `json:"stats,omitempty"`
 
-	PrimaryKeys        []string                `json:"primary_keys,omitempty"`
-	ForeignKeys        []ForeignKeyRef         `json:"foreign_keys,omitempty"`
-	OutgoingRels       []RelationshipRef       `json:"outgoing_relationships,omitempty"`
-	IncomingRels       []RelationshipRef       `json:"incoming_relationships,omitempty"`
-	FKDisambiguation   []FKDisambiguationEntry `json:"fk_disambiguation,omitempty"`
-	Indexes            []IndexInfo             `json:"indexes,omitempty"`
-	Aggregations       *AggregationInfo        `json:"aggregations,omitempty"`
-	ExampleQueries     []ExampleQuery          `json:"example_queries,omitempty"`
-	AnalyticsModeRules []string                `json:"analytics_mode_rules,omitempty"`
-	AggregationHint    string                  `json:"aggregation_hint,omitempty"`
+	PrimaryKeys            []string                `json:"primary_keys,omitempty"`
+	ForeignKeys            []ForeignKeyRef         `json:"foreign_keys,omitempty"`
+	OutgoingRels           []RelationshipRef       `json:"outgoing_relationships,omitempty"`
+	IncomingRels           []RelationshipRef       `json:"incoming_relationships,omitempty"`
+	FKDisambiguation       []FKDisambiguationEntry `json:"fk_disambiguation,omitempty"`
+	Indexes                []IndexInfo             `json:"indexes,omitempty"`
+	Aggregations           *AggregationInfo        `json:"aggregations,omitempty"`
+	ExampleQueries         []ExampleQuery          `json:"example_queries,omitempty"`
+	AnalyticsModeRules     []string                `json:"analytics_mode_rules,omitempty"`
+	AggregationHint        string                  `json:"aggregation_hint,omitempty"`
+	TemporalFilterWarning  string                  `json:"temporal_filter_warning,omitempty"`
 
 	Cost DiscoveryCost `json:"cost"`
 }
 
-// FKDisambiguationEntry signals that this table has multiple foreign keys to
-// the same target. Without a @through(column:) hint the compiler will reject
-// queries that nest the target. The Candidates list names the FK columns and
-// includes paste-ready GraphQL snippets.
+// FKDisambiguationEntry signals multiple FKs to the same target; needs @through(column:).
 type FKDisambiguationEntry struct {
 	Target     string                       `json:"target"`
 	Ambiguous  bool                         `json:"ambiguous"`

--- a/serv/discovery_types.go
+++ b/serv/discovery_types.go
@@ -215,15 +215,34 @@ type TableSampleResult struct {
 	Status   string        `json:"status"`
 	Stats    *TableProfile `json:"stats,omitempty"`
 
-	PrimaryKeys    []string          `json:"primary_keys,omitempty"`
-	ForeignKeys    []ForeignKeyRef   `json:"foreign_keys,omitempty"`
-	OutgoingRels   []RelationshipRef `json:"outgoing_relationships,omitempty"`
-	IncomingRels   []RelationshipRef `json:"incoming_relationships,omitempty"`
-	Indexes        []IndexInfo       `json:"indexes,omitempty"`
-	Aggregations   *AggregationInfo  `json:"aggregations,omitempty"`
-	ExampleQueries []ExampleQuery    `json:"example_queries,omitempty"`
+	PrimaryKeys        []string                `json:"primary_keys,omitempty"`
+	ForeignKeys        []ForeignKeyRef         `json:"foreign_keys,omitempty"`
+	OutgoingRels       []RelationshipRef       `json:"outgoing_relationships,omitempty"`
+	IncomingRels       []RelationshipRef       `json:"incoming_relationships,omitempty"`
+	FKDisambiguation   []FKDisambiguationEntry `json:"fk_disambiguation,omitempty"`
+	Indexes            []IndexInfo             `json:"indexes,omitempty"`
+	Aggregations       *AggregationInfo        `json:"aggregations,omitempty"`
+	ExampleQueries     []ExampleQuery          `json:"example_queries,omitempty"`
+	AnalyticsModeRules []string                `json:"analytics_mode_rules,omitempty"`
+	AggregationHint    string                  `json:"aggregation_hint,omitempty"`
 
 	Cost DiscoveryCost `json:"cost"`
+}
+
+// FKDisambiguationEntry signals that this table has multiple foreign keys to
+// the same target. Without a @through(column:) hint the compiler will reject
+// queries that nest the target. The Candidates list names the FK columns and
+// includes paste-ready GraphQL snippets.
+type FKDisambiguationEntry struct {
+	Target     string                       `json:"target"`
+	Ambiguous  bool                         `json:"ambiguous"`
+	Candidates []FKDisambiguationCandidate  `json:"candidates"`
+	SyntaxHint string                       `json:"syntax_hint"`
+}
+
+type FKDisambiguationCandidate struct {
+	Column  string `json:"column"`
+	Snippet string `json:"snippet"`
 }
 
 type RelationshipRef struct {

--- a/serv/exec_error_augment.go
+++ b/serv/exec_error_augment.go
@@ -6,21 +6,7 @@ import (
 	"strings"
 )
 
-// enhanceExecError augments an exec-time error with structured repair
-// fields, a dialect-derived Kind, and — most importantly — a schema
-// cross-check. When a "column does not exist" error names a column that
-// actually exists on the table, the underlying cause is upstream (the
-// SQL emitter dropped the column from a CTE projection), and the right
-// next step is fix_query_error, NOT describe_table.
-//
-// Returns either:
-//   - the original errMsg unchanged, if no useful classification could
-//     be made and the legacy substring matcher in enhanceError doesn't
-//     hit either;
-//   - a JSON-encoded EnhancedError with structured fields populated.
-//
-// Augments rather than replaces — Message preserves the raw driver text
-// so consumers that already parse it keep working.
+// enhanceExecError augments a driver error with structured repair fields and a schema cross-check; falls back to enhanceError when unclassifiable.
 func (ms *mcpServer) enhanceExecError(errMsg, currentTool string) string {
 	if errMsg == "" {
 		return errMsg
@@ -28,11 +14,6 @@ func (ms *mcpServer) enhanceExecError(errMsg, currentTool string) string {
 
 	dbType := ms.execDBType()
 	class := classifyExecError(dbType, errMsg)
-
-	// If the dialect classifier didn't recognize the shape, fall back to
-	// the legacy substring-based enhanceError. This keeps coverage for
-	// errors that don't fit any per-dialect regex (driver bug strings,
-	// network errors that bubble up from below the SQL layer, etc.).
 	if class.Kind == ExecKindUnknown {
 		return enhanceError(errMsg, currentTool)
 	}
@@ -73,12 +54,7 @@ func (ms *mcpServer) enhanceExecError(errMsg, currentTool string) string {
 	return string(data)
 }
 
-// fillColumnNotFoundAugment is the dialect-agnostic schema cross-check.
-// When the named column actually exists on the named table, the error is
-// a downstream artifact of SQL generation (most commonly: distinct +
-// aggregate dropped the column from a CTE projection — see Stage 3
-// compile-time rejection). When the column genuinely doesn't exist, the
-// suggestion stays at describe_table.
+// fillColumnNotFoundAugment cross-checks against the schema and reframes the error when the column actually exists.
 func (ms *mcpServer) fillColumnNotFoundAugment(enhanced *EnhancedError, class ExecErrorClass) {
 	if class.Column == "" {
 		enhanced.Suggestion = "Column not found. Use describe_table to see available columns."
@@ -103,12 +79,7 @@ func (ms *mcpServer) fillColumnNotFoundAugment(enhanced *EnhancedError, class Ex
 	enhanced.RelatedTool = "describe_table"
 }
 
-// columnExistsAcrossSchema returns whether the column exists on the
-// named table, plus the resolved (case-corrected) table name. When the
-// extracted table name is empty (some dialects don't emit it), it walks
-// every table in the engine looking for the column — a crude fallback,
-// but it's only invoked once per error and the worst case is still
-// O(tables × columns), which is small.
+// columnExistsAcrossSchema reports whether the column exists on the named table; falls back to a full scan when table is empty.
 func (ms *mcpServer) columnExistsAcrossSchema(table, column string) (bool, string) {
 	if ms == nil || ms.service == nil || ms.service.gj == nil {
 		return false, ""
@@ -128,9 +99,6 @@ func (ms *mcpServer) columnExistsAcrossSchema(table, column string) (bool, strin
 		}
 	}
 
-	// Fallback: search across all tables. Useful when the dialect didn't
-	// give us a table name in the error (oracle ORA-00904 sometimes
-	// drops it; mongodb projections, etc.).
 	for _, t := range gj.GetTables() {
 		if schema, err := gj.GetTableSchema(t.Name); err == nil && schema != nil {
 			for _, c := range schema.Columns {
@@ -144,7 +112,6 @@ func (ms *mcpServer) columnExistsAcrossSchema(table, column string) (bool, strin
 }
 
 // execDBType returns the canonical dbType key for the default database.
-// Empty string is treated as postgres by classifyExecError.
 func (ms *mcpServer) execDBType() string {
 	if ms == nil || ms.service == nil || ms.service.gj == nil {
 		return ""

--- a/serv/exec_error_augment.go
+++ b/serv/exec_error_augment.go
@@ -1,0 +1,164 @@
+package serv
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// enhanceExecError augments an exec-time error with structured repair
+// fields, a dialect-derived Kind, and — most importantly — a schema
+// cross-check. When a "column does not exist" error names a column that
+// actually exists on the table, the underlying cause is upstream (the
+// SQL emitter dropped the column from a CTE projection), and the right
+// next step is fix_query_error, NOT describe_table.
+//
+// Returns either:
+//   - the original errMsg unchanged, if no useful classification could
+//     be made and the legacy substring matcher in enhanceError doesn't
+//     hit either;
+//   - a JSON-encoded EnhancedError with structured fields populated.
+//
+// Augments rather than replaces — Message preserves the raw driver text
+// so consumers that already parse it keep working.
+func (ms *mcpServer) enhanceExecError(errMsg, currentTool string) string {
+	if errMsg == "" {
+		return errMsg
+	}
+
+	dbType := ms.execDBType()
+	class := classifyExecError(dbType, errMsg)
+
+	// If the dialect classifier didn't recognize the shape, fall back to
+	// the legacy substring-based enhanceError. This keeps coverage for
+	// errors that don't fit any per-dialect regex (driver bug strings,
+	// network errors that bubble up from below the SQL layer, etc.).
+	if class.Kind == ExecKindUnknown {
+		return enhanceError(errMsg, currentTool)
+	}
+
+	enhanced := EnhancedError{
+		Message: errMsg,
+		Kind:    class.Kind,
+		Table:   class.Table,
+		Column:  class.Column,
+	}
+
+	switch class.Kind {
+	case ExecKindColumnNotFound:
+		ms.fillColumnNotFoundAugment(&enhanced, class)
+	case ExecKindTableNotFound:
+		enhanced.Suggestion = "Table not found. Check spelling and the database/schema namespace; some dialects are case-sensitive."
+		enhanced.RelatedTool = "list_tables"
+		enhanced.Hint = "If the table genuinely exists, the error may be from an alias or the role/permission layer."
+	case ExecKindTypeMismatch:
+		enhanced.Suggestion = "Value cannot be coerced to the column's type. Verify variable types and quoting."
+		enhanced.RelatedTool = "describe_table"
+		enhanced.Hint = "describe_table reports each column's type so you can match the literal/variable shape."
+	case ExecKindSyntaxError:
+		enhanced.Suggestion = "Database rejected the generated SQL as syntactically invalid. This usually means an upstream compiler issue rather than a user mistake."
+		enhanced.RelatedTool = "fix_query_error"
+		enhanced.Hint = "Pass this error and the original GraphQL to fix_query_error for a structured repair."
+	case ExecKindPermission:
+		enhanced.Suggestion = "Current role lacks permission. Check role configuration or use a saved query that's allowlisted."
+		enhanced.RelatedTool = "audit_role_permissions"
+	default:
+		enhanced.Suggestion = "Unrecognized execution error class."
+	}
+
+	data, err := json.Marshal(enhanced)
+	if err != nil {
+		return errMsg
+	}
+	return string(data)
+}
+
+// fillColumnNotFoundAugment is the dialect-agnostic schema cross-check.
+// When the named column actually exists on the named table, the error is
+// a downstream artifact of SQL generation (most commonly: distinct +
+// aggregate dropped the column from a CTE projection — see Stage 3
+// compile-time rejection). When the column genuinely doesn't exist, the
+// suggestion stays at describe_table.
+func (ms *mcpServer) fillColumnNotFoundAugment(enhanced *EnhancedError, class ExecErrorClass) {
+	if class.Column == "" {
+		enhanced.Suggestion = "Column not found. Use describe_table to see available columns."
+		enhanced.RelatedTool = "describe_table"
+		return
+	}
+
+	exists, resolvedTable := ms.columnExistsAcrossSchema(class.Table, class.Column)
+	if exists {
+		enhanced.Table = resolvedTable
+		enhanced.Hint = fmt.Sprintf(
+			"Column '%s' DOES exist on '%s'. The driver-level 'does not exist' here is misleading — it usually means the SQL emitter dropped this column from a CTE projection (e.g. a distinct+aggregate GROUP BY collapsed it). Pass this error and the original GraphQL to fix_query_error for a structured repair instead of re-checking spelling.",
+			class.Column, resolvedTable)
+		enhanced.Suggestion = "Misleading error — column actually exists on the table. Likely an upstream query-shape issue, not a typo."
+		enhanced.RelatedTool = "fix_query_error"
+		return
+	}
+
+	enhanced.Suggestion = fmt.Sprintf(
+		"Column '%s' not found%s. Use describe_table to see available columns.",
+		class.Column, tableSuffix(class.Table))
+	enhanced.RelatedTool = "describe_table"
+}
+
+// columnExistsAcrossSchema returns whether the column exists on the
+// named table, plus the resolved (case-corrected) table name. When the
+// extracted table name is empty (some dialects don't emit it), it walks
+// every table in the engine looking for the column — a crude fallback,
+// but it's only invoked once per error and the worst case is still
+// O(tables × columns), which is small.
+func (ms *mcpServer) columnExistsAcrossSchema(table, column string) (bool, string) {
+	if ms == nil || ms.service == nil || ms.service.gj == nil {
+		return false, ""
+	}
+	gj := ms.service.gj
+	if !gj.SchemaReady() {
+		return false, ""
+	}
+
+	if table != "" {
+		if schema, err := gj.GetTableSchema(table); err == nil && schema != nil {
+			for _, c := range schema.Columns {
+				if strings.EqualFold(c.Name, column) {
+					return true, schema.Name
+				}
+			}
+		}
+	}
+
+	// Fallback: search across all tables. Useful when the dialect didn't
+	// give us a table name in the error (oracle ORA-00904 sometimes
+	// drops it; mongodb projections, etc.).
+	for _, t := range gj.GetTables() {
+		if schema, err := gj.GetTableSchema(t.Name); err == nil && schema != nil {
+			for _, c := range schema.Columns {
+				if strings.EqualFold(c.Name, column) {
+					return true, schema.Name
+				}
+			}
+		}
+	}
+	return false, ""
+}
+
+// execDBType returns the canonical dbType key for the default database.
+// Empty string is treated as postgres by classifyExecError.
+func (ms *mcpServer) execDBType() string {
+	if ms == nil || ms.service == nil || ms.service.gj == nil {
+		return ""
+	}
+	gj := ms.service.gj
+	if _, dbtype, err := gj.DBForDatabase(gj.DefaultDatabase()); err == nil {
+		return dbtype
+	}
+	return ""
+}
+
+func tableSuffix(table string) string {
+	if table == "" {
+		return ""
+	}
+	return " on table '" + table + "'"
+}

--- a/serv/exec_error_classify.go
+++ b/serv/exec_error_classify.go
@@ -5,19 +5,8 @@ import (
 	"strings"
 )
 
-// Exec-time error classifier. Pulls structured info (kind, table, column)
-// out of dialect-specific error strings produced by the SQL drivers, so
-// the augment layer can:
-//   - emit a stable Kind field (consumers don't pattern-match prose)
-//   - cross-check against the schema (a "column does not exist" error
-//     where the column actually exists usually means the SQL emitter
-//     dropped it from a CTE projection — point at fix_query_error rather
-//     than describe_table)
-//
-// Coverage: postgres, mysql, mariadb, sqlite, oracle, mssql, snowflake,
-// mongodb. Patterns derived from each driver's documented error formats.
+// Exec-time error classifier: dialect-specific error strings → {Kind, Table, Column}. Covers all 8 supported dialects.
 
-// Kind constants. Stable strings — consumers may switch on them.
 const (
 	ExecKindColumnNotFound = "column_not_found"
 	ExecKindTableNotFound  = "table_not_found"
@@ -27,18 +16,14 @@ const (
 	ExecKindUnknown        = ""
 )
 
-// ExecErrorClass is the structured classification of a driver-level
-// error message.
+// ExecErrorClass is the parsed shape of a driver-level error.
 type ExecErrorClass struct {
 	Kind   string
-	Table  string // may be empty when not extractable
-	Column string // may be empty when not extractable
+	Table  string
+	Column string
 }
 
-// dialectPatterns maps each supported dbType to its per-kind regexes.
-// Patterns capture the offending identifier in submatch group 1 (the
-// extractor below normalizes "table.column" forms). Order within each
-// dialect is significant — first match wins.
+// dialectPatterns: per-dbType per-kind regex; first match wins, capture group 1 is the offending identifier.
 var dialectPatterns = map[string]map[string]*regexp.Regexp{
 	"postgres": {
 		ExecKindColumnNotFound: regexp.MustCompile(`(?i)column\s+"?([A-Za-z0-9_.]+)"?\s+does not exist`),
@@ -89,19 +74,14 @@ var dialectPatterns = map[string]map[string]*regexp.Regexp{
 		ExecKindPermission:     regexp.MustCompile(`(?i)Insufficient privileges to operate on`),
 	},
 	"mongodb": {
-		// MongoDB's failure model differs — the driver returns aggregation/projection errors
-		// rather than column-not-exist. Patterns below cover the most common shapes we
-		// surface up through the GraphJin MongoDB driver.
+		// MongoDB exposes projection/aggregation errors instead of column-not-exist.
 		ExecKindColumnNotFound: regexp.MustCompile(`(?i)field path\s+'([^']+)'\s+is invalid|FieldPath field names may not start with`),
 		ExecKindTableNotFound:  regexp.MustCompile(`(?i)collection\s+(\S+)\s+(?:does not exist|not found)|ns not found`),
 		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)cannot apply\s+\$\w+\s+to\s+\S+|\$\w+ requires`),
 	},
 }
 
-// classifyExecError parses an exec-time error string into a structured
-// kind plus extracted identifiers. dbType uses the same canonical names
-// as core/internal/sdata (postgres/mysql/mariadb/sqlite/oracle/mssql/
-// snowflake/mongodb). Empty dbType is treated as postgres.
+// classifyExecError parses a driver error into {Kind, Table, Column}; empty dbType defaults to postgres.
 func classifyExecError(dbType, errMsg string) ExecErrorClass {
 	if errMsg == "" {
 		return ExecErrorClass{Kind: ExecKindUnknown}
@@ -136,8 +116,6 @@ func classifyExecError(dbType, errMsg string) ExecErrorClass {
 			ident = m[1]
 		}
 		table, column := splitIdentTableColumn(ident)
-		// For ColumnNotFound the captured ident may be just the column;
-		// for TableNotFound it's the table.
 		if kind == ExecKindTableNotFound {
 			return ExecErrorClass{Kind: kind, Table: stripAliasSuffix(ident)}
 		}
@@ -150,9 +128,7 @@ func classifyExecError(dbType, errMsg string) ExecErrorClass {
 	return ExecErrorClass{Kind: ExecKindUnknown}
 }
 
-// splitIdentTableColumn handles "table.column" and "schema.table.column"
-// forms emitted by various drivers. When only a single identifier is
-// present, it's treated as the column name.
+// splitIdentTableColumn parses "col" / "table.col" / "schema.table.col"; single token treated as column.
 func splitIdentTableColumn(ident string) (table, column string) {
 	if ident == "" {
 		return "", ""
@@ -164,16 +140,11 @@ func splitIdentTableColumn(ident string) (table, column string) {
 	case 2:
 		return parts[0], parts[1]
 	default:
-		// schema.table.column — keep last two
 		return parts[len(parts)-2], parts[len(parts)-1]
 	}
 }
 
-// stripAliasSuffix removes GraphJin's per-select alias suffix
-// (e.g. "salesorderdetail_0" -> "salesorderdetail"). The compiler tags
-// every select with a numeric index so its emitted CTEs don't collide;
-// when a Postgres error references "salesorderdetail_0.salesorderid"
-// the underlying table is salesorderdetail.
+// stripAliasSuffix unwinds the per-select numeric suffix (salesorderdetail_0 → salesorderdetail).
 func stripAliasSuffix(name string) string {
 	if name == "" {
 		return name
@@ -191,9 +162,7 @@ func stripAliasSuffix(name string) string {
 	return name[:i]
 }
 
-// normalizeDBType maps configured dbType values to the canonical key used
-// in dialectPatterns. Keeps "" → postgres (the historical default) and
-// also accepts "pg" / "postgresql" aliases.
+// normalizeDBType maps configured dbType values (incl. aliases like pg/sqlserver) to the canonical dialectPatterns key.
 func normalizeDBType(dbType string) string {
 	switch strings.ToLower(strings.TrimSpace(dbType)) {
 	case "", "postgres", "postgresql", "pg":

--- a/serv/exec_error_classify.go
+++ b/serv/exec_error_classify.go
@@ -1,0 +1,218 @@
+package serv
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Exec-time error classifier. Pulls structured info (kind, table, column)
+// out of dialect-specific error strings produced by the SQL drivers, so
+// the augment layer can:
+//   - emit a stable Kind field (consumers don't pattern-match prose)
+//   - cross-check against the schema (a "column does not exist" error
+//     where the column actually exists usually means the SQL emitter
+//     dropped it from a CTE projection — point at fix_query_error rather
+//     than describe_table)
+//
+// Coverage: postgres, mysql, mariadb, sqlite, oracle, mssql, snowflake,
+// mongodb. Patterns derived from each driver's documented error formats.
+
+// Kind constants. Stable strings — consumers may switch on them.
+const (
+	ExecKindColumnNotFound = "column_not_found"
+	ExecKindTableNotFound  = "table_not_found"
+	ExecKindTypeMismatch   = "type_mismatch"
+	ExecKindSyntaxError    = "syntax_error"
+	ExecKindPermission     = "permission_denied"
+	ExecKindUnknown        = ""
+)
+
+// ExecErrorClass is the structured classification of a driver-level
+// error message.
+type ExecErrorClass struct {
+	Kind   string
+	Table  string // may be empty when not extractable
+	Column string // may be empty when not extractable
+}
+
+// dialectPatterns maps each supported dbType to its per-kind regexes.
+// Patterns capture the offending identifier in submatch group 1 (the
+// extractor below normalizes "table.column" forms). Order within each
+// dialect is significant — first match wins.
+var dialectPatterns = map[string]map[string]*regexp.Regexp{
+	"postgres": {
+		ExecKindColumnNotFound: regexp.MustCompile(`(?i)column\s+"?([A-Za-z0-9_.]+)"?\s+does not exist`),
+		ExecKindTableNotFound:  regexp.MustCompile(`(?i)relation\s+"([A-Za-z0-9_.]+)"\s+does not exist`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)invalid input syntax for (?:type )?(\S+):`),
+		ExecKindSyntaxError:    regexp.MustCompile(`(?i)syntax error at or near\s+"([^"]+)"`),
+		ExecKindPermission:     regexp.MustCompile(`(?i)permission denied for (?:relation|table|schema)\s+"?([A-Za-z0-9_.]+)"?`),
+	},
+	"mysql": {
+		ExecKindColumnNotFound: regexp.MustCompile(`(?i)Unknown column\s+'([^']+)'`),
+		ExecKindTableNotFound:  regexp.MustCompile(`(?i)Table\s+'(?:[^.']+\.)?([^']+)'\s+doesn't exist`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)Incorrect (?:integer|decimal|datetime|date|time|boolean) value:\s+'([^']+)'`),
+		ExecKindSyntaxError:    regexp.MustCompile(`(?i)You have an error in your SQL syntax`),
+		ExecKindPermission:     regexp.MustCompile(`(?i)Access denied|command denied to user`),
+	},
+	"mariadb": {
+		ExecKindColumnNotFound: regexp.MustCompile(`(?i)Unknown column\s+'([^']+)'`),
+		ExecKindTableNotFound:  regexp.MustCompile(`(?i)Table\s+'(?:[^.']+\.)?([^']+)'\s+doesn't exist`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)Incorrect (?:integer|decimal|datetime|date|time|boolean) value:\s+'([^']+)'`),
+		ExecKindSyntaxError:    regexp.MustCompile(`(?i)You have an error in your SQL syntax`),
+		ExecKindPermission:     regexp.MustCompile(`(?i)Access denied|command denied to user`),
+	},
+	"sqlite": {
+		ExecKindColumnNotFound: regexp.MustCompile(`(?i)no such column:\s*([A-Za-z0-9_.]+)`),
+		ExecKindTableNotFound:  regexp.MustCompile(`(?i)no such table:\s*([A-Za-z0-9_.]+)`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)datatype mismatch`),
+		ExecKindSyntaxError:    regexp.MustCompile(`(?i)near\s+"([^"]+)":\s*syntax error`),
+	},
+	"oracle": {
+		ExecKindColumnNotFound: regexp.MustCompile(`ORA-00904:\s*"?([^"]+)"?:\s*invalid identifier`),
+		ExecKindTableNotFound:  regexp.MustCompile(`ORA-00942:\s*table or view does not exist`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`ORA-01722:\s*invalid number|ORA-01858:\s*a non-numeric character`),
+		ExecKindSyntaxError:    regexp.MustCompile(`ORA-00936:\s*missing expression|ORA-00933:\s*SQL command not properly ended`),
+		ExecKindPermission:     regexp.MustCompile(`ORA-00942|ORA-01031:\s*insufficient privileges`),
+	},
+	"mssql": {
+		ExecKindColumnNotFound: regexp.MustCompile(`(?i)Invalid column name\s+'([^']+)'`),
+		ExecKindTableNotFound:  regexp.MustCompile(`(?i)Invalid object name\s+'([^']+)'`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)Conversion failed when converting`),
+		ExecKindSyntaxError:    regexp.MustCompile(`(?i)Incorrect syntax near\s+'([^']+)'`),
+		ExecKindPermission:     regexp.MustCompile(`(?i)permission was denied|cannot find the (?:object|user)`),
+	},
+	"snowflake": {
+		ExecKindColumnNotFound: regexp.MustCompile(`(?i)invalid identifier\s+'([^']+)'`),
+		ExecKindTableNotFound:  regexp.MustCompile(`(?i)Object\s+'([^']+)'\s+does not exist or not authorized`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)Numeric value\s+'([^']+)'\s+is not recognized|Boolean value\s+'([^']+)'\s+is not recognized`),
+		ExecKindSyntaxError:    regexp.MustCompile(`(?i)SQL compilation error.*syntax error`),
+		ExecKindPermission:     regexp.MustCompile(`(?i)Insufficient privileges to operate on`),
+	},
+	"mongodb": {
+		// MongoDB's failure model differs — the driver returns aggregation/projection errors
+		// rather than column-not-exist. Patterns below cover the most common shapes we
+		// surface up through the GraphJin MongoDB driver.
+		ExecKindColumnNotFound: regexp.MustCompile(`(?i)field path\s+'([^']+)'\s+is invalid|FieldPath field names may not start with`),
+		ExecKindTableNotFound:  regexp.MustCompile(`(?i)collection\s+(\S+)\s+(?:does not exist|not found)|ns not found`),
+		ExecKindTypeMismatch:   regexp.MustCompile(`(?i)cannot apply\s+\$\w+\s+to\s+\S+|\$\w+ requires`),
+	},
+}
+
+// classifyExecError parses an exec-time error string into a structured
+// kind plus extracted identifiers. dbType uses the same canonical names
+// as core/internal/sdata (postgres/mysql/mariadb/sqlite/oracle/mssql/
+// snowflake/mongodb). Empty dbType is treated as postgres.
+func classifyExecError(dbType, errMsg string) ExecErrorClass {
+	if errMsg == "" {
+		return ExecErrorClass{Kind: ExecKindUnknown}
+	}
+	patterns, ok := dialectPatterns[normalizeDBType(dbType)]
+	if !ok {
+		return ExecErrorClass{Kind: ExecKindUnknown}
+	}
+
+	// Iterate kinds in a stable order — most specific first. Postgres
+	// for instance can emit both "column does not exist" and a syntax
+	// error in the same message; column wins because it's the more
+	// actionable signal.
+	order := []string{
+		ExecKindColumnNotFound,
+		ExecKindTableNotFound,
+		ExecKindTypeMismatch,
+		ExecKindSyntaxError,
+		ExecKindPermission,
+	}
+	for _, kind := range order {
+		re, has := patterns[kind]
+		if !has {
+			continue
+		}
+		m := re.FindStringSubmatch(errMsg)
+		if m == nil {
+			continue
+		}
+		var ident string
+		if len(m) > 1 {
+			ident = m[1]
+		}
+		table, column := splitIdentTableColumn(ident)
+		// For ColumnNotFound the captured ident may be just the column;
+		// for TableNotFound it's the table.
+		if kind == ExecKindTableNotFound {
+			return ExecErrorClass{Kind: kind, Table: stripAliasSuffix(ident)}
+		}
+		return ExecErrorClass{
+			Kind:   kind,
+			Table:  stripAliasSuffix(table),
+			Column: column,
+		}
+	}
+	return ExecErrorClass{Kind: ExecKindUnknown}
+}
+
+// splitIdentTableColumn handles "table.column" and "schema.table.column"
+// forms emitted by various drivers. When only a single identifier is
+// present, it's treated as the column name.
+func splitIdentTableColumn(ident string) (table, column string) {
+	if ident == "" {
+		return "", ""
+	}
+	parts := strings.Split(ident, ".")
+	switch len(parts) {
+	case 1:
+		return "", parts[0]
+	case 2:
+		return parts[0], parts[1]
+	default:
+		// schema.table.column — keep last two
+		return parts[len(parts)-2], parts[len(parts)-1]
+	}
+}
+
+// stripAliasSuffix removes GraphJin's per-select alias suffix
+// (e.g. "salesorderdetail_0" -> "salesorderdetail"). The compiler tags
+// every select with a numeric index so its emitted CTEs don't collide;
+// when a Postgres error references "salesorderdetail_0.salesorderid"
+// the underlying table is salesorderdetail.
+func stripAliasSuffix(name string) string {
+	if name == "" {
+		return name
+	}
+	i := strings.LastIndex(name, "_")
+	if i <= 0 || i == len(name)-1 {
+		return name
+	}
+	suf := name[i+1:]
+	for _, r := range suf {
+		if r < '0' || r > '9' {
+			return name
+		}
+	}
+	return name[:i]
+}
+
+// normalizeDBType maps configured dbType values to the canonical key used
+// in dialectPatterns. Keeps "" → postgres (the historical default) and
+// also accepts "pg" / "postgresql" aliases.
+func normalizeDBType(dbType string) string {
+	switch strings.ToLower(strings.TrimSpace(dbType)) {
+	case "", "postgres", "postgresql", "pg":
+		return "postgres"
+	case "mysql":
+		return "mysql"
+	case "mariadb":
+		return "mariadb"
+	case "sqlite", "sqlite3":
+		return "sqlite"
+	case "oracle":
+		return "oracle"
+	case "mssql", "sqlserver":
+		return "mssql"
+	case "snowflake":
+		return "snowflake"
+	case "mongodb", "mongo":
+		return "mongodb"
+	default:
+		return dbType
+	}
+}

--- a/serv/mcp_contract_test.go
+++ b/serv/mcp_contract_test.go
@@ -528,6 +528,104 @@ func mapValues(m map[string]string) []string {
 	return values
 }
 
+func TestBuildFixQueryErrorRepair_Arms(t *testing.T) {
+	cases := []struct {
+		name         string
+		errorMsg     string
+		wantKind     string
+		wantInRepair []string
+		wantTools    []string
+	}{
+		{
+			name:         "multi_fk_ambiguity",
+			errorMsg:     `ambiguous relationship orders -> users: multiple foreign keys (customer_id, salesperson_id). Disambiguate by adding @through(column: "customer_id") or @through(column: "salesperson_id") on the nested selection`,
+			wantKind:     fixKindMultiFKAmbiguity,
+			wantInRepair: []string{`@through(column: "customer_id")`, "candidates: customer_id, salesperson_id"},
+			wantTools:    []string{"describe_table", "get_table_sample"},
+		},
+		{
+			name:         "distinct_join_shape",
+			errorMsg:     `nested selection 'salesorderheader' joins through parent column 'salesorderdetail.salesorderid', which is not in distinct: [productid]. The GROUP BY collapses 'salesorderid' away.`,
+			wantKind:     fixKindDistinctJoinShape,
+			wantInRepair: []string{"<dimension_table>", "salesorderdetail", "salesorderheader", "productid"},
+			wantTools:    []string{"get_workflow_guide"},
+		},
+		{
+			name:         "partition_filter_required",
+			errorMsg:     `table "salesorderdetail" requires a filter on temporal column "modifieddate" (e.g., { modifieddate: { gt: "2026-01-01" } }); pass unrestricted: true to override`,
+			wantKind:     fixKindPartitionFilter,
+			wantInRepair: []string{"salesorderdetail", "modifieddate", "unrestricted: true"},
+			wantTools:    []string{"get_table_sample"},
+		},
+		{
+			name:      "unknown_relationship",
+			errorMsg:  `relationship not found: foo -> bar`,
+			wantKind:  fixKindUnknownRelationship,
+			wantTools: []string{"find_path"},
+		},
+		{
+			name:      "table_not_found",
+			errorMsg:  `table not found: usrs`,
+			wantKind:  fixKindTableNotFound,
+			wantTools: []string{"list_tables"},
+		},
+		{
+			name:      "column_not_found_postgres",
+			errorMsg:  `pq: column purchases_0.customer_id does not exist`,
+			wantKind:  fixKindColumnNotFound,
+			wantTools: []string{"describe_table"},
+		},
+		{
+			name:     "generic_fallback",
+			errorMsg: `something completely unexpected happened`,
+			wantKind: fixKindGeneric,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := buildFixQueryErrorRepair("query { foo { bar } }", tc.errorMsg, false)
+			if res.Kind != tc.wantKind {
+				t.Fatalf("kind: got %q want %q", res.Kind, tc.wantKind)
+			}
+			for _, s := range tc.wantInRepair {
+				if !strings.Contains(res.RepairedQuery, s) {
+					t.Errorf("RepairedQuery missing %q. Got:\n%s", s, res.RepairedQuery)
+				}
+			}
+			for _, s := range tc.wantTools {
+				found := false
+				for _, tool := range res.FollowUpTools {
+					if strings.Contains(tool, s) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("FollowUpTools missing %q. Got: %v", s, res.FollowUpTools)
+				}
+			}
+			if !strings.Contains(res.GuideMarkdown, "Query Error Analysis") {
+				t.Errorf("GuideMarkdown missing header")
+			}
+			if !strings.Contains(res.GuideMarkdown, res.Diagnosis) {
+				t.Errorf("GuideMarkdown missing diagnosis text")
+			}
+		})
+	}
+}
+
+func TestBuildFixQueryErrorRepair_AnalyticsModeBlock(t *testing.T) {
+	res := buildFixQueryErrorRepair("query { x }", "table not found: x", true)
+	if !strings.Contains(res.GuideMarkdown, "Analytics Mode Rules") {
+		t.Fatalf("expected analytics-mode block when on; got:\n%s", res.GuideMarkdown)
+	}
+	res = buildFixQueryErrorRepair("query { x }", "table not found: x", false)
+	if strings.Contains(res.GuideMarkdown, "Analytics Mode Rules") {
+		t.Fatal("did not expect analytics-mode block when off")
+	}
+}
+
 func TestDetectFKDisambiguation(t *testing.T) {
 	out := detectFKDisambiguation([]RelationshipRef{
 		{Table: "users", Column: "user_id"},

--- a/serv/mcp_contract_test.go
+++ b/serv/mcp_contract_test.go
@@ -547,8 +547,8 @@ func TestBuildFixQueryErrorRepair_Arms(t *testing.T) {
 			name:         "distinct_join_shape",
 			errorMsg:     `nested selection 'salesorderheader' joins through parent column 'salesorderdetail.salesorderid', which is not in distinct: [productid]. The GROUP BY collapses 'salesorderid' away.`,
 			wantKind:     fixKindDistinctJoinShape,
-			wantInRepair: []string{"<dimension_table>", "salesorderdetail", "salesorderheader", "productid"},
-			wantTools:    []string{"get_workflow_guide"},
+			wantInRepair: []string{"<dimension_table>", "salesorderdetail", "salesorderheader", "productid", "metric_by_dimension"},
+			wantTools:    []string{"get_query_syntax", "get_workflow_guide"},
 		},
 		{
 			name:         "partition_filter_required",
@@ -672,6 +672,39 @@ func TestClassifyExecError_AllDialects(t *testing.T) {
 				t.Errorf("column: got %q want %q", got.Column, tc.wantCol)
 			}
 		})
+	}
+}
+
+func TestCanonicalQueryPatterns(t *testing.T) {
+	patterns := canonicalQueryPatterns()
+	if len(patterns) != 3 {
+		t.Fatalf("expected 3 canonical patterns, got %d", len(patterns))
+	}
+
+	// Stable order: metric_by_dimension first (most common authoring
+	// mistake; should lead).
+	wantOrder := []string{"metric_by_dimension", "time_series", "top_n"}
+	names := make([]string, len(patterns))
+	for i, p := range patterns {
+		names[i] = p.Name
+	}
+	for i, want := range wantOrder {
+		if names[i] != want {
+			t.Errorf("patterns[%d].Name = %q; want %q (full order: %v)", i, names[i], want, names)
+		}
+	}
+
+	for _, p := range patterns {
+		if p.Title == "" || p.Rule == "" || p.Why == "" || p.RightExample == "" {
+			t.Errorf("pattern %q missing required field: %+v", p.Name, p)
+		}
+	}
+
+	// metric_by_dimension MUST carry the wrong/right contrast — the
+	// agent feedback (P3) flagged this as load-bearing for small models.
+	mbd := patterns[0]
+	if mbd.WrongExample == "" || mbd.WrongReason == "" {
+		t.Errorf("metric_by_dimension must include WrongExample and WrongReason (load-bearing per P3)")
 	}
 }
 

--- a/serv/mcp_contract_test.go
+++ b/serv/mcp_contract_test.go
@@ -615,6 +615,84 @@ func TestBuildFixQueryErrorRepair_Arms(t *testing.T) {
 	}
 }
 
+func TestClassifyExecError_AllDialects(t *testing.T) {
+	cases := []struct {
+		name     string
+		dbType   string
+		errMsg   string
+		wantKind string
+		wantTbl  string
+		wantCol  string
+	}{
+		// postgres
+		{"pg_column", "postgres", `pq: column salesorderdetail_0.salesorderid does not exist`, ExecKindColumnNotFound, "salesorderdetail", "salesorderid"},
+		{"pg_table", "postgres", `pq: relation "users" does not exist`, ExecKindTableNotFound, "users", ""},
+		{"pg_type", "postgres", `pq: invalid input syntax for type integer: "abc"`, ExecKindTypeMismatch, "", "integer"},
+		{"pg_perm", "postgres", `pq: permission denied for relation "secrets"`, ExecKindPermission, "", "secrets"},
+		// mysql
+		{"my_column", "mysql", `Error 1054: Unknown column 'foo' in 'field list'`, ExecKindColumnNotFound, "", "foo"},
+		{"my_table", "mysql", `Error 1146: Table 'shop.orders' doesn't exist`, ExecKindTableNotFound, "orders", ""},
+		{"my_type", "mysql", `Error 1366: Incorrect integer value: 'abc' for column 'age' at row 1`, ExecKindTypeMismatch, "", "abc"},
+		// mariadb (same patterns as mysql)
+		{"maria_col", "mariadb", `Error 1054: Unknown column 'bar' in 'where clause'`, ExecKindColumnNotFound, "", "bar"},
+		// sqlite
+		{"sl_column", "sqlite", `no such column: orders.total`, ExecKindColumnNotFound, "orders", "total"},
+		{"sl_table", "sqlite", `no such table: orders`, ExecKindTableNotFound, "orders", ""},
+		{"sl_type", "sqlite", `datatype mismatch`, ExecKindTypeMismatch, "", ""},
+		// oracle
+		{"or_column", "oracle", `ORA-00904: "FOO": invalid identifier`, ExecKindColumnNotFound, "", "FOO"},
+		{"or_table", "oracle", `ORA-00942: table or view does not exist`, ExecKindTableNotFound, "", ""},
+		{"or_type", "oracle", `ORA-01722: invalid number`, ExecKindTypeMismatch, "", ""},
+		// mssql
+		{"ms_column", "mssql", `mssql: Invalid column name 'salesorderid'.`, ExecKindColumnNotFound, "", "salesorderid"},
+		{"ms_table", "mssql", `mssql: Invalid object name 'orders'.`, ExecKindTableNotFound, "orders", ""},
+		// snowflake
+		{"sf_column", "snowflake", `000904 (42000): SQL compilation error: error line 1 at position 7\ninvalid identifier 'NOT_A_COL'`, ExecKindColumnNotFound, "", "NOT_A_COL"},
+		{"sf_table", "snowflake", `Object 'PUBLIC.NOPE' does not exist or not authorized.`, ExecKindTableNotFound, "PUBLIC.NOPE", ""},
+		// mongodb
+		{"mg_field", "mongodb", `field path 'foo.bar' is invalid`, ExecKindColumnNotFound, "foo", "bar"},
+		{"mg_ns", "mongodb", `ns not found`, ExecKindTableNotFound, "", ""},
+		// unknown / aliases
+		{"empty_dbtype_pg_alias", "", `pq: column "x" does not exist`, ExecKindColumnNotFound, "", "x"},
+		{"sqlserver_alias", "sqlserver", `mssql: Invalid column name 'y'.`, ExecKindColumnNotFound, "", "y"},
+		{"unknown_dialect", "duckdb", `something went wrong`, ExecKindUnknown, "", ""},
+		{"empty_msg", "postgres", ``, ExecKindUnknown, "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyExecError(tc.dbType, tc.errMsg)
+			if got.Kind != tc.wantKind {
+				t.Fatalf("kind: got %q want %q (msg=%q)", got.Kind, tc.wantKind, tc.errMsg)
+			}
+			if !strings.EqualFold(got.Table, tc.wantTbl) {
+				t.Errorf("table: got %q want %q", got.Table, tc.wantTbl)
+			}
+			if !strings.EqualFold(got.Column, tc.wantCol) {
+				t.Errorf("column: got %q want %q", got.Column, tc.wantCol)
+			}
+		})
+	}
+}
+
+func TestStripAliasSuffix(t *testing.T) {
+	cases := map[string]string{
+		"":                       "",
+		"orders":                 "orders",
+		"orders_0":               "orders",
+		"salesorderdetail_42":    "salesorderdetail",
+		"order_items":            "order_items", // _items isn't numeric — preserved
+		"orders_":                "orders_",     // trailing underscore — preserved
+		"my_table_5_extra":       "my_table_5_extra", // not a trailing numeric suffix
+		"my_table_5":             "my_table",
+	}
+	for in, want := range cases {
+		if got := stripAliasSuffix(in); got != want {
+			t.Errorf("stripAliasSuffix(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
 func TestBuildFixQueryErrorRepair_AnalyticsModeBlock(t *testing.T) {
 	res := buildFixQueryErrorRepair("query { x }", "table not found: x", true)
 	if !strings.Contains(res.GuideMarkdown, "Analytics Mode Rules") {

--- a/serv/mcp_contract_test.go
+++ b/serv/mcp_contract_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -488,6 +489,43 @@ func newSQLiteMCPServerWithSchema(t *testing.T, ddl []string) *mcpServer {
 	return &mcpServer{service: svc, ctx: context.Background()}
 }
 
+func TestGeneratePathExampleQuery_UsesActualPK(t *testing.T) {
+	resolver := func(table string) string {
+		switch table {
+		case "salesorderdetail":
+			return "salesorderdetailid"
+		case "salesorderheader":
+			return "salesorderid"
+		case "customer":
+			return "customerid"
+		}
+		return ""
+	}
+
+	got := generatePathExampleQuery("salesorderdetail",
+		[]core.PathStep{{To: "salesorderheader"}, {To: "customer"}}, resolver)
+
+	for _, want := range []string{"salesorderdetailid", "salesorderid", "customerid"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected real PK %q in example, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "<pk_column>") {
+		t.Errorf("did not expect placeholder when resolver returns real PKs:\n%s", got)
+	}
+	if regexp.MustCompile(`(?:^|[\s{(\[,])(id|name)(?:[\s})\],]|$)`).MatchString(got) {
+		t.Errorf("example must not contain literal 'id' or 'name' tokens:\n%s", got)
+	}
+}
+
+func TestGeneratePathExampleQuery_FallsBackToPlaceholder(t *testing.T) {
+	got := generatePathExampleQuery("foo",
+		[]core.PathStep{{To: "bar"}}, func(string) string { return "" })
+	if !strings.Contains(got, "<pk_column>") {
+		t.Errorf("expected <pk_column> placeholder when resolver returns empty:\n%s", got)
+	}
+}
+
 func TestValidateExampleQuery_CleanPath(t *testing.T) {
 	ms := newSQLiteMCPServerWithSchema(t, []string{
 		`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`,
@@ -675,6 +713,13 @@ func TestBuildFixQueryErrorRepair_Arms(t *testing.T) {
 			wantTools: []string{"describe_table"},
 		},
 		{
+			name:         "field_not_on_table",
+			errorMsg:     `field 'id' is not a column or a function`,
+			wantKind:     fixKindFieldNotOnTable,
+			wantInRepair: []string{"<actual_pk_column>", "<actual_name_column>"},
+			wantTools:    []string{"describe_table", "get_query_syntax"},
+		},
+		{
 			name:     "generic_fallback",
 			errorMsg: `something completely unexpected happened`,
 			wantKind: fixKindGeneric,
@@ -855,6 +900,25 @@ func TestCanonicalQueryPatterns(t *testing.T) {
 	mbd := patterns[0]
 	if mbd.WrongExample == "" || mbd.WrongReason == "" {
 		t.Errorf("metric_by_dimension must include WrongExample and WrongReason (load-bearing per P3)")
+	}
+
+	// Patterns must use placeholder column names like <pk_column>,
+	// <name_column>, <date_column>. Literal 'id' / 'name' tokens
+	// inside example queries would tempt small models to copy them
+	// verbatim onto tables whose PKs are named differently
+	// (e.g. productcategoryid in AdventureWorks). Allow 'id' / 'name'
+	// as substrings of placeholders — only fail when they appear as
+	// bare identifiers between whitespace/braces.
+	bareIDName := regexp.MustCompile(`(?:^|[\s{(\[,])(id|name)(?:[\s})\],]|$)`)
+	for _, p := range patterns {
+		for label, ex := range map[string]string{"RightExample": p.RightExample, "WrongExample": p.WrongExample} {
+			if ex == "" {
+				continue
+			}
+			if bareIDName.MatchString(ex) {
+				t.Errorf("pattern %q.%s contains a bare 'id' or 'name' literal — use a <pk_column> / <name_column> placeholder so small models don't copy it verbatim:\n%s", p.Name, label, ex)
+			}
+		}
 	}
 }
 

--- a/serv/mcp_contract_test.go
+++ b/serv/mcp_contract_test.go
@@ -527,3 +527,41 @@ func mapValues(m map[string]string) []string {
 	}
 	return values
 }
+
+func TestDetectFKDisambiguation(t *testing.T) {
+	out := detectFKDisambiguation([]RelationshipRef{
+		{Table: "users", Column: "user_id"},
+		{Table: "products", Column: "product_id"},
+	})
+	if len(out) != 0 {
+		t.Fatalf("expected empty disambiguation, got %+v", out)
+	}
+
+	out = detectFKDisambiguation([]RelationshipRef{
+		{Table: "users", Column: "customer_id"},
+		{Table: "users", Column: "salesperson_id"},
+		{Table: "products", Column: "product_id"},
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected 1 disambiguation entry, got %d", len(out))
+	}
+	entry := out[0]
+	if entry.Target != "users" {
+		t.Fatalf("expected target=users, got %s", entry.Target)
+	}
+	if !entry.Ambiguous {
+		t.Fatal("expected Ambiguous=true")
+	}
+	if len(entry.Candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(entry.Candidates))
+	}
+	cols := entry.Candidates[0].Column + "," + entry.Candidates[1].Column
+	if !strings.Contains(cols, "customer_id") || !strings.Contains(cols, "salesperson_id") {
+		t.Fatalf("expected customer_id + salesperson_id, got %s", cols)
+	}
+	for _, c := range entry.Candidates {
+		if !strings.Contains(c.Snippet, "@through(column:") {
+			t.Fatalf("snippet missing @through(column:): %s", c.Snippet)
+		}
+	}
+}

--- a/serv/mcp_contract_test.go
+++ b/serv/mcp_contract_test.go
@@ -438,6 +438,105 @@ func TestHandleGetWorkflowGuide_UsesRegisteredToolSurface(t *testing.T) {
 	})
 }
 
+// newSQLiteMCPServerWithSchema is a sibling of newSQLiteReadyMCPServer that
+// accepts a custom schema/seed SQL slice. Used for multi-FK tests where the
+// default users-only schema can't reproduce ambiguity.
+func newSQLiteMCPServerWithSchema(t *testing.T, ddl []string) *mcpServer {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "app.sqlite3")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	for _, stmt := range ddl {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+
+	mem := afero.NewMemMapFs()
+	fs := newAferoFS(mem, "/")
+
+	conf := &Config{
+		Core: core.Config{DBType: "sqlite", Production: false},
+		Serv: Serv{Production: false},
+	}
+
+	svc := &graphjinService{
+		conf:   conf,
+		dbs:    map[string]*sql.DB{core.DefaultDBName: db},
+		fs:     fs,
+		log:    zaptest.NewLogger(t).Sugar(),
+		tracer: otel.Tracer("graphjin-serv-test"),
+	}
+
+	gj, err := core.NewGraphJin(&conf.Core, db, core.OptionSetFS(fs), core.OptionSetDatabases(svc.dbs))
+	if err != nil {
+		t.Fatalf("init graphjin: %v", err)
+	}
+	t.Cleanup(func() { gj.Close() })
+	// Force synchronous schema discovery so subsequent ExplainQuery calls
+	// see the tables immediately. NewGraphJin only kicks off async polling.
+	if err := gj.Reload(); err != nil {
+		t.Fatalf("reload schema: %v", err)
+	}
+
+	svc.gj = gj
+	return &mcpServer{service: svc, ctx: context.Background()}
+}
+
+func TestValidateExampleQuery_CleanPath(t *testing.T) {
+	ms := newSQLiteMCPServerWithSchema(t, []string{
+		`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`,
+		`CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER REFERENCES users(id), amount NUMERIC)`,
+	})
+
+	compiles, warning := ms.validateExampleQuery("{ orders { id users { id } } }")
+	if !compiles {
+		t.Fatalf("expected clean path to compile; got warning: %+v", warning)
+	}
+	if warning != nil {
+		t.Fatalf("expected no warning on clean compile; got: %+v", warning)
+	}
+}
+
+func TestValidateExampleQuery_AmbiguousFK(t *testing.T) {
+	ms := newSQLiteMCPServerWithSchema(t, []string{
+		`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`,
+		`CREATE TABLE orders (
+			id INTEGER PRIMARY KEY,
+			customer_id INTEGER REFERENCES users(id),
+			salesperson_id INTEGER REFERENCES users(id),
+			amount NUMERIC
+		)`,
+	})
+
+	// Two FKs from orders to users — nesting users without @through(column:)
+	// must produce an *AmbiguousPathError at compile time.
+	compiles, warning := ms.validateExampleQuery("{ orders { id users { id } } }")
+	if compiles {
+		t.Fatal("expected ambiguous-FK example to fail compilation")
+	}
+	if warning == nil {
+		t.Fatal("expected structured warning on failed compile")
+	}
+	if warning.Kind != fixKindMultiFKAmbiguity {
+		t.Errorf("warning kind = %q; want %q (full warning: %+v)", warning.Kind, fixKindMultiFKAmbiguity, warning)
+	}
+	if !strings.Contains(warning.Diagnosis, "foreign keys") {
+		t.Errorf("diagnosis missing 'foreign keys' marker: %q", warning.Diagnosis)
+	}
+	// Repaired query should suggest @through(column: ...) with one of the
+	// candidate columns from the actual schema (customer_id or salesperson_id).
+	if !strings.Contains(warning.RepairedQuery, "customer_id") &&
+		!strings.Contains(warning.RepairedQuery, "salesperson_id") {
+		t.Errorf("repaired query should name a candidate column; got: %s", warning.RepairedQuery)
+	}
+}
+
 func newSQLiteReadyMCPServer(t *testing.T, queries map[string]string, queryVars map[string]string, fragments ...map[string]string) *mcpServer {
 	t.Helper()
 

--- a/serv/mcp_contract_test.go
+++ b/serv/mcp_contract_test.go
@@ -774,6 +774,57 @@ func TestClassifyExecError_AllDialects(t *testing.T) {
 	}
 }
 
+func TestAggregationLimitations(t *testing.T) {
+	limits := aggregationLimitations()
+	if len(limits) == 0 {
+		t.Fatal("expected non-empty aggregation limitations")
+	}
+	// Each limitation must be a complete sentence pointing at a remedy
+	// or a tool — agents read these and need actionable text.
+	for i, l := range limits {
+		if !strings.HasSuffix(l, ".") {
+			t.Errorf("limitation[%d] should end with a period: %q", i, l)
+		}
+	}
+	// The most load-bearing one (matches our Stage 3 compile error)
+	// must explicitly reference the metric_by_dimension pattern, since
+	// that's the canonical fix.
+	joined := strings.Join(limits, "\n")
+	for _, want := range []string{
+		"order_by",
+		"distinct",
+		"metric_by_dimension",
+		"MongoDB",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("limitations should mention %q; got:\n%s", want, joined)
+		}
+	}
+}
+
+func TestGenerateAggregations_UsageReferencesPatterns(t *testing.T) {
+	// Minimal in-memory schema with a numeric column so the aggregation
+	// generator emits sum_/avg_ entries.
+	schema := &core.TableSchema{
+		Name: "purchases",
+		Columns: []core.ColumnInfo{
+			{Name: "id", Type: "bigint", PrimaryKey: true},
+			{Name: "amount", Type: "numeric"},
+		},
+	}
+	agg := generateAggregations(schema)
+
+	if !strings.Contains(agg.Usage, "patterns") {
+		t.Errorf("Usage should reference get_query_syntax.patterns; got: %q", agg.Usage)
+	}
+	if !strings.Contains(agg.Usage, "fix_query_error") {
+		t.Errorf("Usage should reference fix_query_error; got: %q", agg.Usage)
+	}
+	if len(agg.Limitations) == 0 {
+		t.Errorf("Limitations should be populated alongside Usage")
+	}
+}
+
 func TestCanonicalQueryPatterns(t *testing.T) {
 	patterns := canonicalQueryPatterns()
 	if len(patterns) != 3 {

--- a/serv/mcp_fix_query_error.go
+++ b/serv/mcp_fix_query_error.go
@@ -100,19 +100,23 @@ func fillMultiFKArm(res *FixQueryErrorResult, errorMsg string) {
 
 func fillDistinctJoinShapeArm(res *FixQueryErrorResult, errorMsg string) {
 	res.Kind = fixKindDistinctJoinShape
-	res.FollowUpTools = []string{"get_workflow_guide", "get_table_sample", "describe_table"}
+	// get_query_syntax leads — most agents call it before authoring and
+	// it now carries the same QueryPatterns content. get_workflow_guide
+	// is listed too for the workflow-using minority.
+	res.FollowUpTools = []string{"get_query_syntax", "get_workflow_guide", "get_table_sample", "describe_table"}
 
 	m := reNestedShape.FindStringSubmatch(errorMsg)
 	if m == nil {
-		res.Diagnosis = "Cannot nest a join through a column outside the distinct/group-by; root the query at the dimension table instead."
+		res.Diagnosis = "Cannot nest a join through a column outside the distinct/group-by; root the query at the dimension table instead. See get_query_syntax → patterns → metric_by_dimension."
 		return
 	}
 	child, parent, parentCol, distinctCSV := m[1], m[2], m[3], m[4]
 	res.Diagnosis = fmt.Sprintf(
-		"Nested selection '%s' joins through '%s.%s', which is not in distinct: [%s]. The GROUP BY collapses '%s' away, leaving the join undefined. Root at the dimension instead — or drop the nested join.",
+		"Nested selection '%s' joins through '%s.%s', which is not in distinct: [%s]. The GROUP BY collapses '%s' away, leaving the join undefined. Root at the dimension instead (see get_query_syntax → patterns → metric_by_dimension) — or drop the nested join.",
 		child, parent, parentCol, distinctCSV, parentCol)
 	res.RepairedQuery = fmt.Sprintf(
 		`# Option A (preferred): root at the dimension table, nest the fact at the leaf.
+# This is the "metric_by_dimension" pattern — see get_query_syntax.patterns.
 query {
   <dimension_table> {
     id

--- a/serv/mcp_fix_query_error.go
+++ b/serv/mcp_fix_query_error.go
@@ -17,24 +17,26 @@ type FixQueryErrorResult struct {
 }
 
 const (
-	fixKindMultiFKAmbiguity   = "multi_fk_ambiguity"
-	fixKindDistinctJoinShape  = "distinct_aggregate_nested_join_shape"
-	fixKindPartitionFilter    = "partition_filter_required"
+	fixKindMultiFKAmbiguity    = "multi_fk_ambiguity"
+	fixKindDistinctJoinShape   = "distinct_aggregate_nested_join_shape"
+	fixKindPartitionFilter     = "partition_filter_required"
 	fixKindUnknownRelationship = "unknown_relationship"
-	fixKindTableNotFound      = "table_not_found"
-	fixKindColumnNotFound     = "column_not_found"
-	fixKindOperatorInvalid    = "operator_or_syntax_invalid"
-	fixKindSyntaxParse        = "syntax_or_parse_error"
-	fixKindPermission         = "permission_denied"
-	fixKindMutationNotAllowed = "mutation_not_allowed"
-	fixKindVariable           = "variable_error"
-	fixKindGeneric            = "generic"
+	fixKindTableNotFound       = "table_not_found"
+	fixKindColumnNotFound      = "column_not_found"
+	fixKindFieldNotOnTable     = "field_not_on_table"
+	fixKindOperatorInvalid     = "operator_or_syntax_invalid"
+	fixKindSyntaxParse         = "syntax_or_parse_error"
+	fixKindPermission          = "permission_denied"
+	fixKindMutationNotAllowed  = "mutation_not_allowed"
+	fixKindVariable            = "variable_error"
+	fixKindGeneric             = "generic"
 )
 
 var (
-	reAmbiguousRel = regexp.MustCompile(`ambiguous relationship\s+(\S+)\s*->\s*(\S+):\s*multiple foreign keys\s*\(([^)]+)\)`)
-	reNestedShape  = regexp.MustCompile(`nested selection '([^']+)' joins through parent column '([^']+)\.([^']+)', which is not in distinct: \[([^\]]+)\]`)
-	rePartitionReq = regexp.MustCompile(`table\s+"([^"]+)"\s+requires a filter on (?:partition|temporal) column\s+"([^"]+)"`)
+	reAmbiguousRel    = regexp.MustCompile(`ambiguous relationship\s+(\S+)\s*->\s*(\S+):\s*multiple foreign keys\s*\(([^)]+)\)`)
+	reNestedShape     = regexp.MustCompile(`nested selection '([^']+)' joins through parent column '([^']+)\.([^']+)', which is not in distinct: \[([^\]]+)\]`)
+	rePartitionReq    = regexp.MustCompile(`table\s+"([^"]+)"\s+requires a filter on (?:partition|temporal) column\s+"([^"]+)"`)
+	reFieldNotOnTable = regexp.MustCompile(`field '([^']+)' is not a column or a function`)
 )
 
 // buildFixQueryErrorRepair classifies a failing query+error and returns structured repair guidance.
@@ -49,6 +51,8 @@ func buildFixQueryErrorRepair(query, errorMsg string, analyticsMode bool) FixQue
 		fillDistinctJoinShapeArm(&res, errorMsg)
 	case rePartitionReq.MatchString(errorMsg):
 		fillPartitionFilterArm(&res, errorMsg)
+	case reFieldNotOnTable.MatchString(errorMsg):
+		fillFieldNotOnTableArm(&res, errorMsg)
 	case strings.Contains(errLower, "relationship not found"):
 		fillUnknownRelArm(&res, errorMsg)
 	case strings.Contains(errLower, "table") && (strings.Contains(errLower, "not found") || strings.Contains(errLower, "unknown")):
@@ -153,6 +157,34 @@ query {
     id
   }
 }`, table, col, table)
+}
+
+// fillFieldNotOnTableArm covers the common case where a copy-pasted pattern
+// uses placeholder column names (id, name) that don't exist on the actual
+// table. Almost always means the agent took a canonical pattern verbatim
+// instead of substituting in the table's real PK / name columns.
+func fillFieldNotOnTableArm(res *FixQueryErrorResult, errorMsg string) {
+	res.Kind = fixKindFieldNotOnTable
+	res.FollowUpTools = []string{"describe_table", "get_table_sample", "get_query_syntax"}
+
+	m := reFieldNotOnTable.FindStringSubmatch(errorMsg)
+	field := "<field>"
+	if m != nil {
+		field = m[1]
+	}
+	res.Diagnosis = fmt.Sprintf(
+		"Field '%s' isn't a column on the queried table. Most often this means a canonical pattern (e.g. metric_by_dimension) was copied verbatim — those templates use placeholder names like <pk_column> / <name_column> that need to be substituted with this table's real columns.",
+		field)
+	res.RepairedQuery = fmt.Sprintf(
+		`# Use describe_table to find the table's actual primary key and name
+# columns, then substitute them where the pattern said '%s'.
+query {
+  <table> {
+    <actual_pk_column>
+    <actual_name_column>
+    # ... the rest of your selection
+  }
+}`, field)
 }
 
 func fillUnknownRelArm(res *FixQueryErrorResult, errorMsg string) {

--- a/serv/mcp_fix_query_error.go
+++ b/serv/mcp_fix_query_error.go
@@ -1,0 +1,264 @@
+package serv
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// FixQueryErrorResult is the structured tool-result envelope for
+// fix_query_error. It carries both the human-friendly markdown guide and
+// machine-readable repair fields. Small models can read RepairedQuery
+// directly without parsing the markdown; frontier models still get the
+// full prose.
+type FixQueryErrorResult struct {
+	Title         string   `json:"title"`
+	GuideMarkdown string   `json:"guide_markdown"`
+	Kind          string   `json:"kind"`                     // diagnosis class id, see kinds below
+	Diagnosis     string   `json:"diagnosis"`                // one-sentence cause
+	RepairedQuery string   `json:"repaired_query,omitempty"` // paste-ready GraphQL (may contain <placeholder>)
+	FollowUpTools []string `json:"follow_up_tools,omitempty"`
+}
+
+// Diagnosis kinds. Stable string ids so consumers can switch on them.
+const (
+	fixKindMultiFKAmbiguity   = "multi_fk_ambiguity"
+	fixKindDistinctJoinShape  = "distinct_aggregate_nested_join_shape"
+	fixKindPartitionFilter    = "partition_filter_required"
+	fixKindUnknownRelationship = "unknown_relationship"
+	fixKindTableNotFound      = "table_not_found"
+	fixKindColumnNotFound     = "column_not_found"
+	fixKindOperatorInvalid    = "operator_or_syntax_invalid"
+	fixKindSyntaxParse        = "syntax_or_parse_error"
+	fixKindPermission         = "permission_denied"
+	fixKindMutationNotAllowed = "mutation_not_allowed"
+	fixKindVariable           = "variable_error"
+	fixKindGeneric            = "generic"
+)
+
+var (
+	reAmbiguousRel = regexp.MustCompile(`ambiguous relationship\s+(\S+)\s*->\s*(\S+):\s*multiple foreign keys\s*\(([^)]+)\)`)
+	reNestedShape  = regexp.MustCompile(`nested selection '([^']+)' joins through parent column '([^']+)\.([^']+)', which is not in distinct: \[([^\]]+)\]`)
+	rePartitionReq = regexp.MustCompile(`table\s+"([^"]+)"\s+requires a filter on (?:partition|temporal) column\s+"([^"]+)"`)
+)
+
+// buildFixQueryErrorRepair classifies the failing query+error pair and
+// returns structured repair guidance. Pure function — no I/O, safe to
+// call from both the prompt and tool entry points.
+func buildFixQueryErrorRepair(query, errorMsg string, analyticsMode bool) FixQueryErrorResult {
+	res := FixQueryErrorResult{Title: "Query error analysis", Kind: fixKindGeneric}
+	errLower := strings.ToLower(errorMsg)
+
+	switch {
+	case reAmbiguousRel.MatchString(errorMsg):
+		fillMultiFKArm(&res, errorMsg)
+	case reNestedShape.MatchString(errorMsg):
+		fillDistinctJoinShapeArm(&res, errorMsg)
+	case rePartitionReq.MatchString(errorMsg):
+		fillPartitionFilterArm(&res, errorMsg)
+	case strings.Contains(errLower, "relationship not found"):
+		fillUnknownRelArm(&res, errorMsg)
+	case strings.Contains(errLower, "table") && (strings.Contains(errLower, "not found") || strings.Contains(errLower, "unknown")):
+		fillTableNotFoundArm(&res)
+	case strings.Contains(errLower, "column") && (strings.Contains(errLower, "not found") || strings.Contains(errLower, "unknown") || strings.Contains(errLower, "does not exist")):
+		fillColumnNotFoundArm(&res)
+	case strings.Contains(errLower, "operator") || strings.Contains(errLower, "invalid"):
+		fillOperatorArm(&res)
+	case strings.Contains(errLower, "syntax") || strings.Contains(errLower, "parse"):
+		fillSyntaxArm(&res)
+	case strings.Contains(errLower, "permission") || strings.Contains(errLower, "access") || strings.Contains(errLower, "denied"):
+		fillPermissionArm(&res)
+	case strings.Contains(errLower, "mutation") && strings.Contains(errLower, "not allowed"):
+		fillMutationNotAllowedArm(&res)
+	case strings.Contains(errLower, "variable") || strings.Contains(errLower, "$"):
+		fillVariableArm(&res)
+	default:
+		fillGenericArm(&res)
+	}
+
+	res.GuideMarkdown = renderFixMarkdown(query, errorMsg, &res, analyticsMode)
+	return res
+}
+
+func fillMultiFKArm(res *FixQueryErrorResult, errorMsg string) {
+	res.Kind = fixKindMultiFKAmbiguity
+	res.FollowUpTools = []string{"describe_table", "get_table_sample"}
+
+	m := reAmbiguousRel.FindStringSubmatch(errorMsg)
+	if m == nil {
+		res.Diagnosis = "Multiple foreign keys exist between two nested tables; the compiler cannot pick one without a hint."
+		res.RepairedQuery = "query {\n  parent {\n    child @through(column: \"<fk_column>\") {\n      id\n    }\n  }\n}"
+		return
+	}
+	from, to, candCSV := m[1], m[2], m[3]
+	candidates := splitAndTrim(candCSV)
+	res.Diagnosis = fmt.Sprintf("Multiple foreign keys exist between %s and %s. Pick one with @through(column: \"...\"); for composite FKs, naming any column of the composite is enough.", from, to)
+	res.RepairedQuery = fmt.Sprintf(
+		"query {\n  %s {\n    %s @through(column: %q) {\n      id\n    }\n  }\n}\n# candidates: %s",
+		from, to, candidates[0], strings.Join(candidates, ", "))
+}
+
+func fillDistinctJoinShapeArm(res *FixQueryErrorResult, errorMsg string) {
+	res.Kind = fixKindDistinctJoinShape
+	res.FollowUpTools = []string{"get_workflow_guide", "get_table_sample", "describe_table"}
+
+	m := reNestedShape.FindStringSubmatch(errorMsg)
+	if m == nil {
+		res.Diagnosis = "Cannot nest a join through a column outside the distinct/group-by; root the query at the dimension table instead."
+		return
+	}
+	child, parent, parentCol, distinctCSV := m[1], m[2], m[3], m[4]
+	res.Diagnosis = fmt.Sprintf(
+		"Nested selection '%s' joins through '%s.%s', which is not in distinct: [%s]. The GROUP BY collapses '%s' away, leaving the join undefined. Root at the dimension instead — or drop the nested join.",
+		child, parent, parentCol, distinctCSV, parentCol)
+	res.RepairedQuery = fmt.Sprintf(
+		`# Option A (preferred): root at the dimension table, nest the fact at the leaf.
+query {
+  <dimension_table> {
+    id
+    name
+    %s {
+      <metric>: sum(expr: { mul: [<col_a>, <col_b>] })
+    }
+  }
+}
+# Option B: drop the nested '%s' join and only return the per-%s metric.
+query {
+  %s(distinct: [%s]) {
+    %s
+    <metric>: sum(...)
+  }
+}`,
+		parent, child, distinctCSV, parent, distinctCSV, distinctCSV)
+}
+
+func fillPartitionFilterArm(res *FixQueryErrorResult, errorMsg string) {
+	res.Kind = fixKindPartitionFilter
+	res.FollowUpTools = []string{"get_table_sample", "describe_table"}
+
+	m := rePartitionReq.FindStringSubmatch(errorMsg)
+	if m == nil {
+		res.Diagnosis = "This table requires a filter on its partition or temporal column; add a where clause or pass unrestricted: true."
+		return
+	}
+	table, col := m[1], m[2]
+	res.Diagnosis = fmt.Sprintf("Table %q requires a filter on column %q. Add a where clause or pass unrestricted: true (use only when you genuinely want a full scan).", table, col)
+	res.RepairedQuery = fmt.Sprintf(
+		`# Option A (preferred): filter the temporal column.
+query {
+  %s(where: { %s: { gt: "2026-01-01" } }) {
+    id
+  }
+}
+# Option B: bypass the filter (full scan).
+query {
+  %s(unrestricted: true) {
+    id
+  }
+}`, table, col, table)
+}
+
+func fillUnknownRelArm(res *FixQueryErrorResult, errorMsg string) {
+	res.Kind = fixKindUnknownRelationship
+	res.Diagnosis = "GraphJin has no relationship between the named tables. Confirm the join path before retrying."
+	res.FollowUpTools = []string{"find_path", "get_table_sample", "describe_table"}
+	_ = errorMsg
+}
+
+func fillTableNotFoundArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindTableNotFound
+	res.Diagnosis = "Table name not found. Check spelling and namespace; some databases are case-sensitive."
+	res.FollowUpTools = []string{"list_tables", "list_namespaces"}
+}
+
+func fillColumnNotFoundArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindColumnNotFound
+	res.Diagnosis = "Column not found on the named table. If the column actually exists, this often signals an upstream relationship issue (the compiler emitted a CTE that drops the column). Check describe_table; if the column is there, look for a distinct/group-by + nested-join shape mismatch."
+	res.FollowUpTools = []string{"describe_table", "get_table_sample", "fix_query_error"}
+}
+
+func fillOperatorArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindOperatorInvalid
+	res.Diagnosis = "Invalid operator or operand shape."
+	res.FollowUpTools = []string{"get_query_syntax", "validate_where_clause"}
+}
+
+func fillSyntaxArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindSyntaxParse
+	res.Diagnosis = "GraphQL syntax or parse error."
+	res.FollowUpTools = []string{"get_query_syntax"}
+}
+
+func fillPermissionArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindPermission
+	res.Diagnosis = "Permission or access denied for the current role."
+	res.FollowUpTools = []string{"audit_role_permissions", "list_saved_queries"}
+}
+
+func fillMutationNotAllowedArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindMutationNotAllowed
+	res.Diagnosis = "Raw mutations are disabled in this deployment."
+	res.FollowUpTools = []string{"list_saved_queries", "execute_saved_query"}
+}
+
+func fillVariableArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindVariable
+	res.Diagnosis = "Variable reference is missing, mistyped, or unbound."
+	res.FollowUpTools = []string{"get_query_syntax"}
+}
+
+func fillGenericArm(res *FixQueryErrorResult) {
+	res.Kind = fixKindGeneric
+	res.Diagnosis = "Unrecognized error class — fall back to schema verification and incremental query simplification."
+	res.FollowUpTools = []string{"list_tables", "describe_table", "get_query_syntax", "list_saved_queries"}
+}
+
+func splitAndTrim(csv string) []string {
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// renderFixMarkdown produces the human-readable guide. Backwards-compatible
+// with the prompt-style consumer that only sees text.
+func renderFixMarkdown(query, errorMsg string, res *FixQueryErrorResult, analyticsMode bool) string {
+	var sb strings.Builder
+	sb.WriteString("# Query Error Analysis\n\n")
+	if analyticsMode {
+		sb.WriteString(analyticsModeBlockMarkdown())
+	}
+
+	sb.WriteString("## Error Message\n```\n")
+	sb.WriteString(errorMsg)
+	sb.WriteString("\n```\n\n")
+
+	sb.WriteString("## Original Query\n```graphql\n")
+	sb.WriteString(query)
+	sb.WriteString("\n```\n\n")
+
+	sb.WriteString("## Diagnosis\n")
+	sb.WriteString(fmt.Sprintf("**Kind**: `%s`\n\n", res.Kind))
+	sb.WriteString(res.Diagnosis)
+	sb.WriteString("\n\n")
+
+	if res.RepairedQuery != "" {
+		sb.WriteString("## Repaired Query\n```graphql\n")
+		sb.WriteString(res.RepairedQuery)
+		sb.WriteString("\n```\n\n")
+	}
+
+	if len(res.FollowUpTools) > 0 {
+		sb.WriteString("## Recommended Next Steps\n")
+		for _, t := range res.FollowUpTools {
+			sb.WriteString(fmt.Sprintf("- Call `%s`\n", t))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}

--- a/serv/mcp_fix_query_error.go
+++ b/serv/mcp_fix_query_error.go
@@ -6,21 +6,16 @@ import (
 	"strings"
 )
 
-// FixQueryErrorResult is the structured tool-result envelope for
-// fix_query_error. It carries both the human-friendly markdown guide and
-// machine-readable repair fields. Small models can read RepairedQuery
-// directly without parsing the markdown; frontier models still get the
-// full prose.
+// FixQueryErrorResult is the structured tool-result envelope for fix_query_error.
 type FixQueryErrorResult struct {
 	Title         string   `json:"title"`
 	GuideMarkdown string   `json:"guide_markdown"`
-	Kind          string   `json:"kind"`                     // diagnosis class id, see kinds below
-	Diagnosis     string   `json:"diagnosis"`                // one-sentence cause
-	RepairedQuery string   `json:"repaired_query,omitempty"` // paste-ready GraphQL (may contain <placeholder>)
+	Kind          string   `json:"kind"`
+	Diagnosis     string   `json:"diagnosis"`
+	RepairedQuery string   `json:"repaired_query,omitempty"`
 	FollowUpTools []string `json:"follow_up_tools,omitempty"`
 }
 
-// Diagnosis kinds. Stable string ids so consumers can switch on them.
 const (
 	fixKindMultiFKAmbiguity   = "multi_fk_ambiguity"
 	fixKindDistinctJoinShape  = "distinct_aggregate_nested_join_shape"
@@ -42,9 +37,7 @@ var (
 	rePartitionReq = regexp.MustCompile(`table\s+"([^"]+)"\s+requires a filter on (?:partition|temporal) column\s+"([^"]+)"`)
 )
 
-// buildFixQueryErrorRepair classifies the failing query+error pair and
-// returns structured repair guidance. Pure function — no I/O, safe to
-// call from both the prompt and tool entry points.
+// buildFixQueryErrorRepair classifies a failing query+error and returns structured repair guidance.
 func buildFixQueryErrorRepair(query, errorMsg string, analyticsMode bool) FixQueryErrorResult {
 	res := FixQueryErrorResult{Title: "Query error analysis", Kind: fixKindGeneric}
 	errLower := strings.ToLower(errorMsg)
@@ -228,8 +221,7 @@ func splitAndTrim(csv string) []string {
 	return out
 }
 
-// renderFixMarkdown produces the human-readable guide. Backwards-compatible
-// with the prompt-style consumer that only sees text.
+// renderFixMarkdown produces the human-readable markdown guide.
 func renderFixMarkdown(query, errorMsg string, res *FixQueryErrorResult, analyticsMode bool) string {
 	var sb strings.Builder
 	sb.WriteString("# Query Error Analysis\n\n")

--- a/serv/mcp_guidance_tools.go
+++ b/serv/mcp_guidance_tools.go
@@ -159,9 +159,15 @@ func (ms *mcpServer) handleFixQueryErrorTool(ctx context.Context, req mcp.CallTo
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	res, err := ms.handleFixQueryError(ctx, promptReq)
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+	query := promptReq.Params.Arguments["query"]
+	errorMsg := promptReq.Params.Arguments["error"]
+	if query == "" {
+		return mcp.NewToolResultError("query argument is required"), nil
 	}
-	return ms.guidanceToolResult("fix_query_error", req.GetArguments(), res)
+	if errorMsg == "" {
+		return mcp.NewToolResultError("error argument is required"), nil
+	}
+
+	repair := buildFixQueryErrorRepair(query, errorMsg, ms.analyticsModeOn())
+	return ms.toolResultJSON("fix_query_error", req.GetArguments(), repair)
 }

--- a/serv/mcp_mode_blocks.go
+++ b/serv/mcp_mode_blocks.go
@@ -1,0 +1,42 @@
+package serv
+
+import "strings"
+
+// Single source of truth for the rules that apply when a database is in
+// analytics mode. Restated across every discovery surface so an agent that
+// reads `analytics_mode: true` early doesn't lose the implications by the
+// time they're building a query (they don't re-read the overview).
+
+func analyticsModeRules() []string {
+	return []string{
+		"No defensive limit:. Implicit row-limit defaults are off — explicit limit: only when you want a top-N.",
+		"Aggregations: root the query at the dimension table (small side) and nest down to the fact table. Never root at the fact table and try to bucket with distinct.",
+		"distinct: dedupes rows; it does NOT bucket. There is no GROUP BY at non-root levels — only the root selection produces aggregate output.",
+		"order_by does not work on aggregation aliases (sum_*, count_*). Sort aggregated results in workflow JavaScript.",
+		"Temporal columns require either an explicit filter or @unrestricted. Unfiltered scans of large fact tables are rejected.",
+		"Partition-keyed tables require the partition column in the where clause (per dialect partition rules).",
+		"Use sum(expr: { mul: [a, b] }) and similar expression aggregates to compute composite measures server-side instead of paginating raw rows.",
+	}
+}
+
+func analyticsModeBlockMarkdown() string {
+	var sb strings.Builder
+	sb.WriteString("## Analytics Mode Rules\n\n")
+	sb.WriteString("This database is in analytics mode. The following rules govern how queries must be shaped:\n\n")
+	for _, r := range analyticsModeRules() {
+		sb.WriteString("- ")
+		sb.WriteString(r)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// analyticsModeOn reports whether the default database is in analytics mode.
+// Returns false if the engine is not yet wired up (during onboarding).
+func (ms *mcpServer) analyticsModeOn() bool {
+	if ms == nil || ms.service == nil || ms.service.gj == nil {
+		return false
+	}
+	return ms.service.gj.EffectiveAnalyticsMode(ms.service.gj.DefaultDatabase())
+}

--- a/serv/mcp_mode_blocks.go
+++ b/serv/mcp_mode_blocks.go
@@ -2,10 +2,7 @@ package serv
 
 import "strings"
 
-// Single source of truth for the rules that apply when a database is in
-// analytics mode. Restated across every discovery surface so an agent that
-// reads `analytics_mode: true` early doesn't lose the implications by the
-// time they're building a query (they don't re-read the overview).
+// Single source of truth for analytics-mode rules; restated across every discovery surface.
 
 func analyticsModeRules() []string {
 	return []string{
@@ -32,8 +29,7 @@ func analyticsModeBlockMarkdown() string {
 	return sb.String()
 }
 
-// analyticsModeOn reports whether the default database is in analytics mode.
-// Returns false if the engine is not yet wired up (during onboarding).
+// analyticsModeOn reports analytics-mode for the default database (false if engine not yet wired).
 func (ms *mcpServer) analyticsModeOn() bool {
 	if ms == nil || ms.service == nil || ms.service.gj == nil {
 		return false

--- a/serv/mcp_prompts.go
+++ b/serv/mcp_prompts.go
@@ -718,7 +718,10 @@ func (ms *mcpServer) handleWriteMutation(ctx context.Context, req mcp.GetPromptR
 	), nil
 }
 
-// handleFixQueryError analyzes query errors and provides fix suggestions
+// handleFixQueryError analyzes query errors and provides structured fix
+// suggestions. The repair logic lives in buildFixQueryErrorRepair so the
+// tool variant can return both the markdown guide AND the structured
+// fields (kind, diagnosis, repaired_query, follow_up_tools).
 func (ms *mcpServer) handleFixQueryError(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 	query := req.Params.Arguments["query"]
 	errorMsg := req.Params.Arguments["error"]
@@ -730,112 +733,13 @@ func (ms *mcpServer) handleFixQueryError(ctx context.Context, req mcp.GetPromptR
 		return nil, fmt.Errorf("error argument is required")
 	}
 
-	var sb strings.Builder
-
-	sb.WriteString("# Query Error Analysis\n\n")
-	if ms.analyticsModeOn() {
-		sb.WriteString(analyticsModeBlockMarkdown())
-	}
-	sb.WriteString("## Error Message\n")
-	sb.WriteString("```\n")
-	sb.WriteString(errorMsg)
-	sb.WriteString("\n```\n\n")
-
-	sb.WriteString("## Original Query\n")
-	sb.WriteString("```graphql\n")
-	sb.WriteString(query)
-	sb.WriteString("\n```\n\n")
-
-	// Analyze the error and provide suggestions
-	sb.WriteString("## Diagnosis & Suggestions\n\n")
-
-	errorLower := strings.ToLower(errorMsg)
-
-	switch {
-	case strings.Contains(errorLower, "ambiguous relationship") ||
-		(strings.Contains(errorLower, "multiple foreign keys") && !strings.Contains(errorLower, "composite")):
-		sb.WriteString("**Problem**: Multiple foreign keys exist between these two tables; the compiler can't pick one without a hint.\n\n")
-		sb.WriteString("**Fix**: add `@through(column: \"<fk_column>\")` to the nested selection. The error message above lists the candidate columns — pick the one that matches the relationship semantics you want.\n\n")
-		sb.WriteString("```graphql\n")
-		sb.WriteString("query {\n")
-		sb.WriteString("  parent {\n")
-		sb.WriteString("    child @through(column: \"<fk_column>\") {\n")
-		sb.WriteString("      id\n")
-		sb.WriteString("    }\n")
-		sb.WriteString("  }\n")
-		sb.WriteString("}\n")
-		sb.WriteString("```\n")
-		sb.WriteString("\nFor composite foreign keys, naming any column of the composite is enough — the compiler uses the full constraint.\n")
-
-	case strings.Contains(errorLower, "table") && (strings.Contains(errorLower, "not found") || strings.Contains(errorLower, "unknown")):
-		sb.WriteString("**Problem**: Table name not found in schema\n\n")
-		sb.WriteString("**Solutions**:\n")
-		sb.WriteString("1. Check spelling of the table name\n")
-		sb.WriteString("2. Use `list_tables` tool to see available tables\n")
-		sb.WriteString("3. Table names are case-sensitive in some databases\n")
-
-	case strings.Contains(errorLower, "column") && (strings.Contains(errorLower, "not found") || strings.Contains(errorLower, "unknown")):
-		sb.WriteString("**Problem**: Column name not found in table\n\n")
-		sb.WriteString("**Solutions**:\n")
-		sb.WriteString("1. Check spelling of the column name\n")
-		sb.WriteString("2. Use `describe_table` tool to see available columns\n")
-		sb.WriteString("3. For JSON fields, use underscore notation: `metadata_key` for `metadata->key`\n")
-
-	case strings.Contains(errorLower, "operator") || strings.Contains(errorLower, "invalid"):
-		sb.WriteString("**Problem**: Invalid operator or syntax\n\n")
-		sb.WriteString("**Solutions**:\n")
-		sb.WriteString("1. Check operator spelling (eq, neq, gt, gte, lt, lte, in, nin, like, ilike)\n")
-		sb.WriteString("2. Numeric operators (gt, lt, etc.) need numeric values, not strings\n")
-		sb.WriteString("3. `in`/`nin` operators need arrays: `{ in: [1, 2] }` not `{ in: 1 }`\n")
-		sb.WriteString("4. Use `get_query_syntax` tool for complete operator reference\n")
-
-	case strings.Contains(errorLower, "syntax") || strings.Contains(errorLower, "parse"):
-		sb.WriteString("**Problem**: Query syntax error\n\n")
-		sb.WriteString("**Solutions**:\n")
-		sb.WriteString("1. Check for missing braces `{ }` or parentheses `( )`\n")
-		sb.WriteString("2. Ensure proper comma usage between fields\n")
-		sb.WriteString("3. Verify string values are quoted: `{ eq: \"value\" }`\n")
-		sb.WriteString("4. Check that `where:` is properly formatted as an object\n")
-
-	case strings.Contains(errorLower, "permission") || strings.Contains(errorLower, "access") || strings.Contains(errorLower, "denied"):
-		sb.WriteString("**Problem**: Permission or access denied\n\n")
-		sb.WriteString("**Solutions**:\n")
-		sb.WriteString("1. Check if mutations are enabled in config (`allow_mutations`)\n")
-		sb.WriteString("2. Check if raw queries are enabled (`allow_raw_queries`)\n")
-		sb.WriteString("3. Verify user has proper role for the operation\n")
-		sb.WriteString("4. Try using a saved query with `execute_saved_query` instead\n")
-
-	case strings.Contains(errorLower, "mutation") && strings.Contains(errorLower, "not allowed"):
-		sb.WriteString("**Problem**: Mutations are disabled\n\n")
-		sb.WriteString("**Solutions**:\n")
-		sb.WriteString("1. Enable mutations in config: `mcp.allow_mutations: true`\n")
-		sb.WriteString("2. Use a pre-approved saved mutation with `execute_saved_query`\n")
-
-	case strings.Contains(errorLower, "variable") || strings.Contains(errorLower, "$"):
-		sb.WriteString("**Problem**: Variable error\n\n")
-		sb.WriteString("**Solutions**:\n")
-		sb.WriteString("1. Ensure all `$variable` references have corresponding values\n")
-		sb.WriteString("2. Pass variables in the `variables` parameter\n")
-		sb.WriteString("3. Check variable types match expected values\n")
-
-	default:
-		sb.WriteString("**General debugging steps**:\n\n")
-		sb.WriteString("1. Use `list_tables` and `describe_table` to verify schema\n")
-		sb.WriteString("2. Use `get_query_syntax` or `get_mutation_syntax` for syntax reference\n")
-		sb.WriteString("3. Simplify the query and add complexity incrementally\n")
-		sb.WriteString("4. Check if a working saved query exists with `list_saved_queries`\n")
-	}
-
-	sb.WriteString("\n## Recommended Next Steps\n\n")
-	sb.WriteString("1. Fix the identified issue\n")
-	sb.WriteString("2. Execute the corrected query\n")
-
+	repair := buildFixQueryErrorRepair(query, errorMsg, ms.analyticsModeOn())
 	return mcp.NewGetPromptResult(
-		"Query error analysis",
+		repair.Title,
 		[]mcp.PromptMessage{
 			mcp.NewPromptMessage(
 				mcp.RoleAssistant,
-				mcp.NewTextContent(sb.String()),
+				mcp.NewTextContent(repair.GuideMarkdown),
 			),
 		},
 	), nil

--- a/serv/mcp_prompts.go
+++ b/serv/mcp_prompts.go
@@ -733,6 +733,9 @@ func (ms *mcpServer) handleFixQueryError(ctx context.Context, req mcp.GetPromptR
 	var sb strings.Builder
 
 	sb.WriteString("# Query Error Analysis\n\n")
+	if ms.analyticsModeOn() {
+		sb.WriteString(analyticsModeBlockMarkdown())
+	}
 	sb.WriteString("## Error Message\n")
 	sb.WriteString("```\n")
 	sb.WriteString(errorMsg)
@@ -749,6 +752,21 @@ func (ms *mcpServer) handleFixQueryError(ctx context.Context, req mcp.GetPromptR
 	errorLower := strings.ToLower(errorMsg)
 
 	switch {
+	case strings.Contains(errorLower, "ambiguous relationship") ||
+		(strings.Contains(errorLower, "multiple foreign keys") && !strings.Contains(errorLower, "composite")):
+		sb.WriteString("**Problem**: Multiple foreign keys exist between these two tables; the compiler can't pick one without a hint.\n\n")
+		sb.WriteString("**Fix**: add `@through(column: \"<fk_column>\")` to the nested selection. The error message above lists the candidate columns — pick the one that matches the relationship semantics you want.\n\n")
+		sb.WriteString("```graphql\n")
+		sb.WriteString("query {\n")
+		sb.WriteString("  parent {\n")
+		sb.WriteString("    child @through(column: \"<fk_column>\") {\n")
+		sb.WriteString("      id\n")
+		sb.WriteString("    }\n")
+		sb.WriteString("  }\n")
+		sb.WriteString("}\n")
+		sb.WriteString("```\n")
+		sb.WriteString("\nFor composite foreign keys, naming any column of the composite is enough — the compiler uses the full constraint.\n")
+
 	case strings.Contains(errorLower, "table") && (strings.Contains(errorLower, "not found") || strings.Contains(errorLower, "unknown")):
 		sb.WriteString("**Problem**: Table name not found in schema\n\n")
 		sb.WriteString("**Solutions**:\n")

--- a/serv/mcp_query_patterns.go
+++ b/serv/mcp_query_patterns.go
@@ -1,0 +1,85 @@
+package serv
+
+// Three canonical query shapes for GraphJin. Surfaced both in
+// get_workflow_guide and get_query_syntax so an agent reaches them
+// regardless of which discovery surface they land on.
+//
+// The Wrong/Right contrast is load-bearing: small models pattern-match
+// on counter-examples just as readily as on positive ones, and the most
+// common authoring mistake is rooting at the fact table for a
+// metric-by-dimension question.
+
+type QueryPattern struct {
+	Name         string `json:"name"`
+	Title        string `json:"title"`
+	Question     string `json:"question"`
+	Rule         string `json:"rule"`
+	Why          string `json:"why"`
+	WrongExample string `json:"wrong_example,omitempty"`
+	WrongReason  string `json:"wrong_reason,omitempty"`
+	RightExample string `json:"right_example"`
+}
+
+func canonicalQueryPatterns() []QueryPattern {
+	return []QueryPattern{
+		{
+			Name:     "metric_by_dimension",
+			Title:    "Metric by dimension",
+			Question: "Examples: revenue by category, users by country, orders by region.",
+			Rule:     "Root at the dimension table. Nest down to the fact table. Aggregate at the LEAF.",
+			Why:      "GraphJin has no GROUP BY at non-root levels. Bucketing happens by choice of root, not by distinct: on a nested FK. distinct: dedupes rows; it does not bucket.",
+			WrongExample: `query {
+  fact_table(distinct: [dimension_fk]) {
+    sum_metric
+  }
+}`,
+			WrongReason:  "distinct on a fact-table FK dedupes rows but does not produce per-dimension aggregates. The compiler will reject this when the nested join references a column outside the distinct list.",
+			RightExample: `query {
+  dimension_table {
+    id
+    name
+    fact_table {
+      sum_metric
+    }
+  }
+}`,
+		},
+		{
+			Name:     "time_series",
+			Title:    "Time series",
+			Question: "Examples: revenue per month, signups per day, sessions per hour.",
+			Rule:     "Root at the fact table. distinct: [date_col]. Aggregate at the same level.",
+			Why:      "Time buckets are produced by the date column itself; there's no separate dimension table to root at. distinct on the date column groups rows by bucket; the aggregate runs over each group.",
+			RightExample: `query {
+  fact_table(distinct: [date_col], order_by: { date_col: asc }) {
+    date_col
+    sum_metric
+  }
+}`,
+		},
+		{
+			Name:     "top_n",
+			Title:    "Top-N entities by metric",
+			Question: "Examples: top 10 customers by spend, top 5 products by revenue.",
+			Rule:     "Root at the fact table. distinct: [entity_fk]. order_by the aggregate desc + limit.",
+			Why:      "Top-N is a ranked-cut over per-entity aggregates. Rooting at the fact and grouping by the entity FK gives one row per entity; ordering by the aggregate alias and limiting yields the top N.",
+			WrongExample: `query {
+  fact_table(distinct: [entity_fk], order_by: { sum_amount: desc }, limit: 10) {
+    entity_fk
+    sum_amount
+    entity_table { name }
+  }
+}
+# (the nested entity_table join here would fail — it joins through
+# entity_fk which IS in distinct, so this specific shape compiles, but
+# nesting any OTHER join through a non-distinct FK would not)`,
+			WrongReason:  "Nesting through a non-distinct FK column is rejected (a column dropped by GROUP BY cannot be a join key). Only nest joins whose FK column is itself in distinct.",
+			RightExample: `query {
+  fact_table(distinct: [customer_id], order_by: { sum_amount: desc }, limit: 10) {
+    customer_id
+    sum_amount: sum(amount)
+  }
+}`,
+		},
+	}
+}

--- a/serv/mcp_query_patterns.go
+++ b/serv/mcp_query_patterns.go
@@ -20,19 +20,19 @@ func canonicalQueryPatterns() []QueryPattern {
 			Title:    "Metric by dimension",
 			Question: "Examples: revenue by category, users by country, orders by region.",
 			Rule:     "Root at the dimension table. Nest down to the fact table. Aggregate at the LEAF.",
-			Why:      "GraphJin has no GROUP BY at non-root levels. Bucketing happens by choice of root, not by distinct: on a nested FK. distinct: dedupes rows; it does not bucket.",
+			Why:      "GraphJin has no GROUP BY at non-root levels. Bucketing happens by choice of root, not by distinct: on a nested FK. distinct: dedupes rows; it does not bucket. Placeholders below (<dimension_table>, <pk_column>, etc.) are generic — substitute with this database's actual names.",
 			WrongExample: `query {
-  fact_table(distinct: [dimension_fk]) {
-    sum_metric
+  <fact_table>(distinct: [<dimension_fk>]) {
+    sum_<metric>
   }
 }`,
 			WrongReason:  "distinct on a fact-table FK dedupes rows but does not produce per-dimension aggregates. The compiler will reject this when the nested join references a column outside the distinct list.",
 			RightExample: `query {
-  dimension_table {
-    id
-    name
-    fact_table {
-      sum_metric
+  <dimension_table> {
+    <pk_column>
+    <name_column>
+    <fact_table> {
+      <metric_alias>: sum(<numeric_col>)
     }
   }
 }`,
@@ -41,12 +41,12 @@ func canonicalQueryPatterns() []QueryPattern {
 			Name:     "time_series",
 			Title:    "Time series",
 			Question: "Examples: revenue per month, signups per day, sessions per hour.",
-			Rule:     "Root at the fact table. distinct: [date_col]. Aggregate at the same level.",
+			Rule:     "Root at the fact table. distinct: [<date_column>]. Aggregate at the same level.",
 			Why:      "Time buckets are produced by the date column itself; there's no separate dimension table to root at. distinct on the date column groups rows by bucket; the aggregate runs over each group.",
 			RightExample: `query {
-  fact_table(distinct: [date_col], order_by: { date_col: asc }) {
-    date_col
-    sum_metric
+  <fact_table>(distinct: [<date_column>], order_by: { <date_column>: asc }) {
+    <date_column>
+    <metric_alias>: sum(<numeric_col>)
   }
 }`,
 		},
@@ -54,23 +54,22 @@ func canonicalQueryPatterns() []QueryPattern {
 			Name:     "top_n",
 			Title:    "Top-N entities by metric",
 			Question: "Examples: top 10 customers by spend, top 5 products by revenue.",
-			Rule:     "Root at the fact table. distinct: [entity_fk]. order_by the aggregate desc + limit.",
+			Rule:     "Root at the fact table. distinct: [<entity_fk>]. order_by the aggregate desc + limit.",
 			Why:      "Top-N is a ranked-cut over per-entity aggregates. Rooting at the fact and grouping by the entity FK gives one row per entity; ordering by the aggregate alias and limiting yields the top N.",
 			WrongExample: `query {
-  fact_table(distinct: [entity_fk], order_by: { sum_amount: desc }, limit: 10) {
-    entity_fk
-    sum_amount
-    entity_table { name }
+  <fact_table>(distinct: [<entity_fk>], order_by: { <metric_alias>: desc }, limit: 10) {
+    <entity_fk>
+    <metric_alias>: sum(<amount_col>)
+    <other_dimension_table> { <name_column> }
   }
 }
-# (the nested entity_table join here would fail — it joins through
-# entity_fk which IS in distinct, so this specific shape compiles, but
-# nesting any OTHER join through a non-distinct FK would not)`,
+# Nesting <other_dimension_table> would fail because its FK is NOT in
+# distinct. Only nest joins whose FK is the same column listed in distinct.`,
 			WrongReason:  "Nesting through a non-distinct FK column is rejected (a column dropped by GROUP BY cannot be a join key). Only nest joins whose FK column is itself in distinct.",
 			RightExample: `query {
-  fact_table(distinct: [customer_id], order_by: { sum_amount: desc }, limit: 10) {
-    customer_id
-    sum_amount: sum(amount)
+  <fact_table>(distinct: [<entity_fk>], order_by: { <metric_alias>: desc }, limit: 10) {
+    <entity_fk>
+    <metric_alias>: sum(<amount_col>)
   }
 }`,
 		},

--- a/serv/mcp_query_patterns.go
+++ b/serv/mcp_query_patterns.go
@@ -1,13 +1,6 @@
 package serv
 
-// Three canonical query shapes for GraphJin. Surfaced both in
-// get_workflow_guide and get_query_syntax so an agent reaches them
-// regardless of which discovery surface they land on.
-//
-// The Wrong/Right contrast is load-bearing: small models pattern-match
-// on counter-examples just as readily as on positive ones, and the most
-// common authoring mistake is rooting at the fact table for a
-// metric-by-dimension question.
+// Three canonical query shapes; Wrong/Right contrast is load-bearing for small-model pattern matching.
 
 type QueryPattern struct {
 	Name         string `json:"name"`

--- a/serv/mcp_schema.go
+++ b/serv/mcp_schema.go
@@ -255,8 +255,9 @@ func intArg(v any) int {
 
 // AggregationInfo describes available aggregation functions for a table
 type AggregationInfo struct {
-	Available []string `json:"available"`
-	Usage     string   `json:"usage"`
+	Available   []string `json:"available"`
+	Usage       string   `json:"usage"`
+	Limitations []string `json:"limitations,omitempty"`
 }
 
 // TableSchemaWithAggregations extends TableSchema with aggregation information
@@ -384,9 +385,26 @@ func generateAggregations(schema *core.TableSchema) AggregationInfo {
 		Usage: fmt.Sprintf(
 			"Single column: { %s { count_id sum_<numeric_col> avg_<numeric_col> } }. "+
 				"Arithmetic across columns (revenue, margin, ratios): "+
-				"{ %s { revenue: sum(expr: { mul: [col_a, col_b] }) } } — "+
-				"call get_query_syntax for the full expression grammar.",
+				"{ %s { revenue: sum(expr: { mul: [col_a, col_b] }) } }. "+
+				"For metric-by-dimension shape (revenue by category, etc.) root at the dimension table — see get_query_syntax.patterns. "+
+				"On compile error, pass query+error to fix_query_error for a structured repair.",
 			schema.Name, schema.Name),
+		Limitations: aggregationLimitations(),
+	}
+}
+
+// aggregationLimitations enumerates the known compose-failures small
+// models might otherwise retry blindly. Static — same list for every
+// table. Each entry pairs the constraint with how to detect/repair it,
+// so the response is self-describing rather than requiring the agent to
+// hit the failure first.
+func aggregationLimitations() []string {
+	return []string{
+		"order_by does not work on aggregate aliases (sum_*, count_*, custom names from sum(expr:)). Sort aggregated results in workflow JavaScript.",
+		"Aggregates at non-root nested levels work but the GROUP BY happens at the root selection only. distinct: dedupes rows; it does not bucket.",
+		"Nesting a join through a column that is not in distinct: of an aggregating select is rejected at compile time — root at the dimension table instead. See get_query_syntax.patterns.metric_by_dimension.",
+		"Recursive (find:) selections cannot contain aggregate fields at the same level — fold via parent if needed.",
+		"MongoDB does not support expression aggregates (sum(expr:)) in the v1 driver — fall back to per-column aggregates.",
 	}
 }
 

--- a/serv/mcp_schema.go
+++ b/serv/mcp_schema.go
@@ -796,6 +796,16 @@ type EnhancedError struct {
 	Message     string `json:"message"`
 	Suggestion  string `json:"suggestion,omitempty"`
 	RelatedTool string `json:"related_tool,omitempty"`
+	// Kind, Table, Column are populated by enhanceExecError when the
+	// error came from SQL execution and the dialect was identifiable.
+	// Consumers can switch on Kind without parsing the prose.
+	Kind   string `json:"kind,omitempty"`
+	Table  string `json:"table,omitempty"`
+	Column string `json:"column,omitempty"`
+	// Hint carries a structured rewrite when the schema cross-check
+	// detects that the error is misleading (e.g. column actually exists
+	// on the table but was dropped by a CTE projection).
+	Hint string `json:"hint,omitempty"`
 }
 
 // enhanceError adds helpful suggestions to common error messages

--- a/serv/mcp_schema.go
+++ b/serv/mcp_schema.go
@@ -862,7 +862,7 @@ func enhanceError(errMsg, currentTool string) string {
 	// Pattern matching for common errors
 	switch {
 	case contains(errMsg, "@through"):
-		enhanced.Suggestion = "@through(table:) takes the name of an intermediate join table (for many-to-many). @through(column:) takes the name of the FK column to follow when the parent has multiple foreign keys to the same target table. Check the spelling of the table or column name."
+		enhanced.Suggestion = "@through(table:) takes the name of an intermediate join table (for many-to-many). @through(column:) takes the name of the FK column to follow when the parent has multiple foreign keys to the same target table — for composite FKs, naming any one column of the composite is sufficient. Check the spelling of the table or column name."
 		enhanced.RelatedTool = "get_query_syntax"
 	case contains(errMsg, "table not found", "unknown table", "does not exist", "no such table", "table doesn't exist"):
 		enhanced.Suggestion = "Check spelling or use list_tables to see available tables. The table may exist in a different database - use list_tables to see all databases."

--- a/serv/mcp_schema.go
+++ b/serv/mcp_schema.go
@@ -506,10 +506,22 @@ func (ms *mcpServer) getNamespace() string {
 
 // WorkflowGuide contains the recommended workflow for using GraphJin MCP tools
 type WorkflowGuide struct {
-	QueryWorkflow    []string          `json:"query_workflow"`
-	MutationWorkflow []string          `json:"mutation_workflow"`
-	Tips             []string          `json:"tips"`
-	ToolSequences    map[string]string `json:"tool_sequences"`
+	QueryWorkflow         []string          `json:"query_workflow"`
+	MutationWorkflow      []string          `json:"mutation_workflow"`
+	Tips                  []string          `json:"tips"`
+	AnalyticsModeRules    []string          `json:"analytics_mode_rules,omitempty"`
+	AggregateByDimension  *AggregationGuide `json:"aggregate_by_dimension,omitempty"`
+	ToolSequences         map[string]string `json:"tool_sequences"`
+}
+
+// AggregationGuide explains how to shape "measure-by-dimension" queries
+// against GraphJin's no-GROUP-BY-at-nested-levels model. Surfaced when
+// analytics mode is on; agents lose this rule between schema overview and
+// query authoring without explicit re-statement.
+type AggregationGuide struct {
+	Rule    string `json:"rule"`
+	Why     string `json:"why"`
+	Example string `json:"example"`
 }
 
 // handleGetWorkflowGuide returns the recommended workflow for MCP tool usage
@@ -570,12 +582,14 @@ func (ms *mcpServer) handleGetWorkflowGuide(ctx context.Context, req mcp.CallToo
 		guide.MutationWorkflow = append(guide.MutationWorkflow, "4. Raw mutations are disabled, so execute a saved mutation with execute_saved_query")
 	}
 
-	analyticsMode := ms.service.gj != nil && ms.service.gj.EffectiveAnalyticsMode(ms.service.gj.DefaultDatabase())
+	analyticsMode := ms.analyticsModeOn()
 	if analyticsMode {
-		guide.Tips = append(guide.Tips,
-			"This database is in ANALYTICS MODE — compute answers server-side with aggregates (count_*, sum_*, sum(expr: { mul: [...] }), distinct: [group_col], filtered where:). Multiple targeted queries are fine; DO NOT paginate raw rows to build totals client-side. See get_query_syntax → Expression Aggregates.",
-			"Analytics mode: implicit row-limit defaults are OFF for this database. Queries without an explicit limit return the full result. Use explicit limit: only when you want a top-N.",
-		)
+		guide.AnalyticsModeRules = analyticsModeRules()
+		guide.AggregateByDimension = &AggregationGuide{
+			Rule: "To aggregate a measure by a dimension, root the query at the dimension table (small side) and nest down to the fact table. Place sum/count at the leaf.",
+			Why:  "GraphJin has no GROUP BY at non-root selections. distinct: dedupes rows but does not bucket. Rooting at the fact table and trying to group via distinct will not produce per-dimension aggregates.",
+			Example: "query {\n  product_category {\n    name\n    product_subcategory {\n      product {\n        sales_order_detail {\n          revenue: sum(expr: { mul: [unitprice, orderqty] })\n        }\n      }\n    }\n  }\n}",
+		}
 	} else {
 		guide.Tips = append(guide.Tips,
 			"ALWAYS use execute_workflow for data questions — NEVER execute_graphql directly. Tables can have hundreds of thousands of rows and you cannot predict sizes.",

--- a/serv/mcp_schema.go
+++ b/serv/mcp_schema.go
@@ -107,8 +107,10 @@ func (ms *mcpServer) registerSchemaTools() {
 			mcp.Description("Optional database name. Omit to search all databases."),
 		),
 		mcp.WithOutputSchema[struct {
-			Path         []core.PathStep `json:"path"`
-			ExampleQuery string          `json:"example_query"`
+			Path                 []core.PathStep      `json:"path"`
+			ExampleQuery         string               `json:"example_query"`
+			ExampleQueryCompiles bool                 `json:"example_query_compiles"`
+			ExampleQueryWarning  *FixQueryErrorResult `json:"example_query_warning,omitempty"`
 		}](),
 	), ms.handleFindPath)
 
@@ -462,17 +464,55 @@ func (ms *mcpServer) handleFindPath(ctx context.Context, req mcp.CallToolRequest
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	// Generate an example query
+	// Generate an example query and validate it compiles. Per agent feedback
+	// (P2), small models treat example_query as ground truth — returning a
+	// non-compiling example causes loops. We don't auto-repair the example
+	// (that'd require GraphQL AST manipulation), but we annotate so the
+	// agent knows to disambiguate via @through(column:) etc.
 	exampleQuery := generatePathExampleQuery(fromTable, toTable, path)
+	compiles, warning := ms.validateExampleQuery(exampleQuery)
 
 	result := struct {
-		Path         []core.PathStep `json:"path"`
-		ExampleQuery string          `json:"example_query"`
+		Path                 []core.PathStep      `json:"path"`
+		ExampleQuery         string               `json:"example_query"`
+		ExampleQueryCompiles bool                 `json:"example_query_compiles"`
+		ExampleQueryWarning  *FixQueryErrorResult `json:"example_query_warning,omitempty"`
 	}{
-		Path:         path,
-		ExampleQuery: exampleQuery,
+		Path:                 path,
+		ExampleQuery:         exampleQuery,
+		ExampleQueryCompiles: compiles,
+		ExampleQueryWarning:  warning,
 	}
 	return ms.toolResultJSON("find_path", args, result)
+}
+
+// validateExampleQuery runs the generated example through ExplainQuery
+// (compile-only, no execution) and returns either (true, nil) or
+// (false, structured-warning) depending on whether it compiles. Reuses
+// the fix_query_error machinery so the warning carries the same Kind /
+// Diagnosis / RepairedQuery shape the agent already knows how to read.
+//
+// ExplainQuery returns (explanation, nil) for COMPILE errors — it stuffs
+// the message into explanation.Errors rather than the Go error return —
+// so we have to check both channels.
+func (ms *mcpServer) validateExampleQuery(exampleQuery string) (bool, *FixQueryErrorResult) {
+	if exampleQuery == "" {
+		return false, nil
+	}
+	if ms == nil || ms.service == nil || ms.service.gj == nil {
+		return false, nil
+	}
+	exp, err := ms.service.gj.ExplainQuery(exampleQuery, nil, "")
+	switch {
+	case err != nil:
+		repair := buildFixQueryErrorRepair(exampleQuery, err.Error(), ms.analyticsModeOn())
+		return false, &repair
+	case exp != nil && len(exp.Errors) > 0:
+		repair := buildFixQueryErrorRepair(exampleQuery, exp.Errors[0], ms.analyticsModeOn())
+		return false, &repair
+	default:
+		return true, nil
+	}
 }
 
 // generatePathExampleQuery generates an example GraphQL query based on the path

--- a/serv/mcp_schema.go
+++ b/serv/mcp_schema.go
@@ -506,22 +506,12 @@ func (ms *mcpServer) getNamespace() string {
 
 // WorkflowGuide contains the recommended workflow for using GraphJin MCP tools
 type WorkflowGuide struct {
-	QueryWorkflow         []string          `json:"query_workflow"`
-	MutationWorkflow      []string          `json:"mutation_workflow"`
-	Tips                  []string          `json:"tips"`
-	AnalyticsModeRules    []string          `json:"analytics_mode_rules,omitempty"`
-	AggregateByDimension  *AggregationGuide `json:"aggregate_by_dimension,omitempty"`
-	ToolSequences         map[string]string `json:"tool_sequences"`
-}
-
-// AggregationGuide explains how to shape "measure-by-dimension" queries
-// against GraphJin's no-GROUP-BY-at-nested-levels model. Surfaced when
-// analytics mode is on; agents lose this rule between schema overview and
-// query authoring without explicit re-statement.
-type AggregationGuide struct {
-	Rule    string `json:"rule"`
-	Why     string `json:"why"`
-	Example string `json:"example"`
+	QueryWorkflow      []string          `json:"query_workflow"`
+	MutationWorkflow   []string          `json:"mutation_workflow"`
+	Tips               []string          `json:"tips"`
+	AnalyticsModeRules []string          `json:"analytics_mode_rules,omitempty"`
+	QueryPatterns      []QueryPattern    `json:"query_patterns,omitempty"`
+	ToolSequences      map[string]string `json:"tool_sequences"`
 }
 
 // handleGetWorkflowGuide returns the recommended workflow for MCP tool usage
@@ -585,17 +575,16 @@ func (ms *mcpServer) handleGetWorkflowGuide(ctx context.Context, req mcp.CallToo
 	analyticsMode := ms.analyticsModeOn()
 	if analyticsMode {
 		guide.AnalyticsModeRules = analyticsModeRules()
-		guide.AggregateByDimension = &AggregationGuide{
-			Rule: "To aggregate a measure by a dimension, root the query at the dimension table (small side) and nest down to the fact table. Place sum/count at the leaf.",
-			Why:  "GraphJin has no GROUP BY at non-root selections. distinct: dedupes rows but does not bucket. Rooting at the fact table and trying to group via distinct will not produce per-dimension aggregates.",
-			Example: "query {\n  product_category {\n    name\n    product_subcategory {\n      product {\n        sales_order_detail {\n          revenue: sum(expr: { mul: [unitprice, orderqty] })\n        }\n      }\n    }\n  }\n}",
-		}
 	} else {
 		guide.Tips = append(guide.Tips,
 			"ALWAYS use execute_workflow for data questions — NEVER execute_graphql directly. Tables can have hundreds of thousands of rows and you cannot predict sizes.",
 			"Every query level has a silent default row limit. Always set explicit limits on every level, especially nested children.",
 		)
 	}
+
+	// Three universal query shapes. Surfaced unconditionally — patterns
+	// are general DSL-shape guidance, not analytics-mode-specific.
+	guide.QueryPatterns = canonicalQueryPatterns()
 
 	guide.Tips = append(guide.Tips,
 		"ALWAYS call list_workflows first — reuse an existing workflow if one fits the question.",

--- a/serv/mcp_schema.go
+++ b/serv/mcp_schema.go
@@ -482,12 +482,11 @@ func (ms *mcpServer) handleFindPath(ctx context.Context, req mcp.CallToolRequest
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	// Generate an example query and validate it compiles. Per agent feedback
-	// (P2), small models treat example_query as ground truth — returning a
-	// non-compiling example causes loops. We don't auto-repair the example
-	// (that'd require GraphQL AST manipulation), but we annotate so the
-	// agent knows to disambiguate via @through(column:) etc.
-	exampleQuery := generatePathExampleQuery(fromTable, toTable, path)
+	// Generate an example query that uses each step's actual PK column
+	// (small models would otherwise copy literal `id` and trip on tables
+	// whose PK is named differently — e.g. AdventureWorks productcategoryid).
+	// validateExampleQuery still runs as a belt-and-suspenders check.
+	exampleQuery := generatePathExampleQuery(fromTable, path, ms.resolvePKColumn)
 	compiles, warning := ms.validateExampleQuery(exampleQuery)
 
 	result := struct {
@@ -533,16 +532,47 @@ func (ms *mcpServer) validateExampleQuery(exampleQuery string) (bool, *FixQueryE
 	}
 }
 
-// generatePathExampleQuery generates an example GraphQL query based on the path
-func generatePathExampleQuery(from, to string, path []core.PathStep) string {
+// resolvePKColumn looks up a table's primary key column for example-query
+// substitution. Returns "" when the table is not found (caller substitutes
+// a placeholder).
+func (ms *mcpServer) resolvePKColumn(table string) string {
+	if ms == nil || ms.service == nil || ms.service.gj == nil {
+		return ""
+	}
+	schema, err := ms.service.gj.GetTableSchema(table)
+	if err != nil || schema == nil {
+		return ""
+	}
+	if schema.PrimaryKey != "" {
+		return schema.PrimaryKey
+	}
+	if len(schema.PrimaryKeys) > 0 {
+		return schema.PrimaryKeys[0]
+	}
+	return ""
+}
+
+// generatePathExampleQuery generates a nested example GraphQL query along
+// the resolved path. resolvePK is called per table to substitute the actual
+// PK column name (falls back to "<pk_column>" when unknown).
+func generatePathExampleQuery(from string, path []core.PathStep, resolvePK func(string) string) string {
 	if len(path) == 0 {
 		return ""
 	}
 
-	// Simple nested query structure
-	query := "{ " + from + " { id "
+	pkOrPlaceholder := func(table string) string {
+		if resolvePK == nil {
+			return "<pk_column>"
+		}
+		if pk := resolvePK(table); pk != "" {
+			return pk
+		}
+		return "<pk_column>"
+	}
+
+	query := "{ " + from + " { " + pkOrPlaceholder(from) + " "
 	for _, step := range path {
-		query += step.To + " { id "
+		query += step.To + " { " + pkOrPlaceholder(step.To) + " "
 	}
 
 	// Close all the braces

--- a/serv/mcp_syntax.go
+++ b/serv/mcp_syntax.go
@@ -9,6 +9,7 @@ import (
 // QuerySyntaxReference contains the complete GraphJin query DSL reference
 type QuerySyntaxReference struct {
 	AnalyticsModeRules []string               `json:"analytics_mode_rules,omitempty"`
+	Patterns           []QueryPattern         `json:"patterns,omitempty"`
 	FilterOperators    FilterOperators        `json:"filter_operators"`
 	LogicalOperators   []string               `json:"logical_operators"`
 	Pagination         PaginationSyntax       `json:"pagination"`
@@ -435,6 +436,10 @@ func (ms *mcpServer) handleGetQuerySyntax(ctx context.Context, req mcp.CallToolR
 	if ms.analyticsModeOn() {
 		ref.AnalyticsModeRules = analyticsModeRules()
 	}
+	// Three universal query shapes (metric-by-dimension, time-series,
+	// top-N). Surfaced unconditionally — patterns are general DSL-shape
+	// guidance, not analytics-mode-specific.
+	ref.Patterns = canonicalQueryPatterns()
 	return ms.toolResultJSON("get_query_syntax", req.GetArguments(), ref)
 }
 

--- a/serv/mcp_syntax.go
+++ b/serv/mcp_syntax.go
@@ -199,7 +199,7 @@ var querySyntaxReference = QuerySyntaxReference{
 		"@object":                "Return single object instead of array",
 		"@schema(name:)":         "Use specific database schema",
 		"@through(table:)":       "Specify the intermediate join table for many-to-many relationships",
-		"@through(column:)":      "Disambiguate when the parent and the nested target share multiple foreign keys — name the FK column to follow. Example: billofmaterials { product @through(column: \"componentid\") { name } }",
+		"@through(column:)":      "Disambiguate when the parent and the nested target share multiple foreign keys — name the FK column to follow. For composite foreign keys (e.g. (term_id, course_id)), naming any one column of the composite is sufficient: the compiler resolves the full constraint and emits all join conditions. Example: billofmaterials { product @through(column: \"componentid\") { name } }",
 		"@notRelated":            "Disable automatic relationship detection for a field",
 		"@cacheControl(maxAge:)": "Set cache TTL in seconds for this query",
 		"@database(name:)":       "Assign table to a named database (REQUIRED on every table when multiple databases are configured). Used in schema definitions, e.g.: type users @database(name: \"mydb\") { ... }",

--- a/serv/mcp_syntax.go
+++ b/serv/mcp_syntax.go
@@ -8,18 +8,19 @@ import (
 
 // QuerySyntaxReference contains the complete GraphJin query DSL reference
 type QuerySyntaxReference struct {
-	FilterOperators  FilterOperators        `json:"filter_operators"`
-	LogicalOperators []string               `json:"logical_operators"`
-	Pagination       PaginationSyntax       `json:"pagination"`
-	Ordering         OrderingSyntax         `json:"ordering"`
-	Aggregations     AggregationsSyntax     `json:"aggregations"`
-	Recursive        RecursiveSyntax        `json:"recursive"`
-	FullTextSearch   string                 `json:"full_text_search"`
-	Directives       map[string]string      `json:"directives"`
-	Variables        VariablesSyntax        `json:"variables"`
-	JSONPaths        string                 `json:"json_paths"`
-	CommonMistakes   []MistakeExample       `json:"common_mistakes"`
-	Examples         QueryExamplesForSyntax `json:"examples"`
+	AnalyticsModeRules []string               `json:"analytics_mode_rules,omitempty"`
+	FilterOperators    FilterOperators        `json:"filter_operators"`
+	LogicalOperators   []string               `json:"logical_operators"`
+	Pagination         PaginationSyntax       `json:"pagination"`
+	Ordering           OrderingSyntax         `json:"ordering"`
+	Aggregations       AggregationsSyntax     `json:"aggregations"`
+	Recursive          RecursiveSyntax        `json:"recursive"`
+	FullTextSearch     string                 `json:"full_text_search"`
+	Directives         map[string]string      `json:"directives"`
+	Variables          VariablesSyntax        `json:"variables"`
+	JSONPaths          string                 `json:"json_paths"`
+	CommonMistakes     []MistakeExample       `json:"common_mistakes"`
+	Examples           QueryExamplesForSyntax `json:"examples"`
 }
 
 // AggregationsSyntax describes available aggregation functions
@@ -92,13 +93,14 @@ type RecursiveSyntax struct {
 
 // MutationSyntaxReference contains the GraphJin mutation DSL reference
 type MutationSyntaxReference struct {
-	Operations        MutationOperations `json:"operations"`
-	NestedMutations   NestedMutationInfo `json:"nested_mutations"`
-	ConnectDisconnect ConnectDisconnect  `json:"connect_disconnect"`
-	Returning         ReturningInfo      `json:"returning"`
-	Validation        ValidationSyntax   `json:"validation"`
-	CommonMistakes    []MistakeExample   `json:"common_mistakes"`
-	Examples          []QueryExample     `json:"examples"`
+	AnalyticsModeRules []string           `json:"analytics_mode_rules,omitempty"`
+	Operations         MutationOperations `json:"operations"`
+	NestedMutations    NestedMutationInfo `json:"nested_mutations"`
+	ConnectDisconnect  ConnectDisconnect  `json:"connect_disconnect"`
+	Returning          ReturningInfo      `json:"returning"`
+	Validation         ValidationSyntax   `json:"validation"`
+	CommonMistakes     []MistakeExample   `json:"common_mistakes"`
+	Examples           []QueryExample     `json:"examples"`
 }
 
 // ReturningInfo describes the returning clause behavior
@@ -429,10 +431,18 @@ func (ms *mcpServer) registerSyntaxTools() {
 
 // handleGetQuerySyntax returns the query syntax reference
 func (ms *mcpServer) handleGetQuerySyntax(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return ms.toolResultJSON("get_query_syntax", req.GetArguments(), querySyntaxReference)
+	ref := querySyntaxReference
+	if ms.analyticsModeOn() {
+		ref.AnalyticsModeRules = analyticsModeRules()
+	}
+	return ms.toolResultJSON("get_query_syntax", req.GetArguments(), ref)
 }
 
 // handleGetMutationSyntax returns the mutation syntax reference
 func (ms *mcpServer) handleGetMutationSyntax(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return ms.toolResultJSON("get_mutation_syntax", req.GetArguments(), mutationSyntaxReference)
+	ref := mutationSyntaxReference
+	if ms.analyticsModeOn() {
+		ref.AnalyticsModeRules = analyticsModeRules()
+	}
+	return ms.toolResultJSON("get_mutation_syntax", req.GetArguments(), ref)
 }

--- a/serv/mcp_syntax.go
+++ b/serv/mcp_syntax.go
@@ -199,7 +199,7 @@ var querySyntaxReference = QuerySyntaxReference{
 		"@object":                "Return single object instead of array",
 		"@schema(name:)":         "Use specific database schema",
 		"@through(table:)":       "Specify the intermediate join table for many-to-many relationships",
-		"@through(column:)":      "Disambiguate when the parent and the nested target share multiple foreign keys — name the FK column to follow. For composite foreign keys (e.g. (term_id, course_id)), naming any one column of the composite is sufficient: the compiler resolves the full constraint and emits all join conditions. Example: billofmaterials { product @through(column: \"componentid\") { name } }",
+		"@through(column:)":      "Disambiguate when the parent and the nested target share multiple foreign keys — name the FK column to follow. For composite foreign keys, naming any one column of the composite is sufficient. Example: billofmaterials { product @through(column: \"componentid\") { name } }",
 		"@notRelated":            "Disable automatic relationship detection for a field",
 		"@cacheControl(maxAge:)": "Set cache TTL in seconds for this query",
 		"@database(name:)":       "Assign table to a named database (REQUIRED on every table when multiple databases are configured). Used in schema definitions, e.g.: type users @database(name: \"mydb\") { ... }",

--- a/serv/mcp_tools.go
+++ b/serv/mcp_tools.go
@@ -128,12 +128,12 @@ func (ms *mcpServer) handleExecuteGraphQL(ctx context.Context, req mcp.CallToolR
 
 	result := ExecuteResult{}
 	if err != nil {
-		result.Errors = []ErrorInfo{{Message: enhanceError(err.Error(), "execute_graphql")}}
+		result.Errors = []ErrorInfo{{Message: ms.enhanceExecError(err.Error(), "execute_graphql")}}
 	} else {
 		// Replace encrypted cursors with short numeric IDs for LLM-friendly responses
 		result.Data = ms.processCursorsForMCP(ctx, res.Data)
 		for _, e := range res.Errors {
-			result.Errors = append(result.Errors, ErrorInfo{Message: enhanceError(e.Message, "execute_graphql")})
+			result.Errors = append(result.Errors, ErrorInfo{Message: ms.enhanceExecError(e.Message, "execute_graphql")})
 		}
 	}
 	return ms.toolResultJSON("execute_graphql", args, result)
@@ -178,12 +178,12 @@ func (ms *mcpServer) handleExecuteSavedQuery(ctx context.Context, req mcp.CallTo
 
 	result := ExecuteResult{}
 	if err != nil {
-		result.Errors = []ErrorInfo{{Message: enhanceError(err.Error(), "execute_saved_query")}}
+		result.Errors = []ErrorInfo{{Message: ms.enhanceExecError(err.Error(), "execute_saved_query")}}
 	} else {
 		// Replace encrypted cursors with short numeric IDs for LLM-friendly responses
 		result.Data = ms.processCursorsForMCP(ctx, res.Data)
 		for _, e := range res.Errors {
-			result.Errors = append(result.Errors, ErrorInfo{Message: enhanceError(e.Message, "execute_saved_query")})
+			result.Errors = append(result.Errors, ErrorInfo{Message: ms.enhanceExecError(e.Message, "execute_saved_query")})
 		}
 	}
 	return ms.toolResultJSON("execute_saved_query", args, result)

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -2497,4 +2498,84 @@ func Example_queryWithGlobalAggBrokenMdFix() {
 		printJSON(res.Data)
 	}
 	// Output: {"products":[{"count_id":100}]}
+}
+
+// TestStage3_DistinctAggregateNestedJoinThroughNonDistinctColumn reproduces
+// the agent's reported failure, root-caused via AdventureWorks:
+//
+// When a query is rooted at a table with `distinct: [col_a]` AND any
+// aggregate AND a nested join referencing a FK column that is NOT in the
+// distinct list, the compiler emits a GROUP BY CTE that drops the FK
+// column, then a lateral join referencing it on the aliased CTE. Postgres
+// rejects with:
+//
+//	ERROR: column salesorderdetail_0.salesorderid does not exist
+//
+// The agent's original framing (sum(expr:) is required) is a red herring —
+// plain sum_<col> triggers the same path. The actual trigger is "GROUP BY
+// drops a column the nested lateral join still references".
+//
+// Semantically the query is ambiguous (many join-key values per group), so
+// the right fix is for the compiler to reject this shape with a clear
+// "cannot nest join through column outside distinct/group-by; root at the
+// dimension table instead" message — not to emit broken SQL.
+//
+// Skipped on mongodb (different aggregation model) and snowflake
+// (unrelated correlated-subquery limit).
+func TestStage3_DistinctAggregateNestedJoinThroughNonDistinctColumn(t *testing.T) {
+	if dbType == "mongodb" || dbType == "snowflake" {
+		t.Skipf("skipping for %s", dbType)
+	}
+
+	conf := newConfig(&core.Config{DBType: dbType, DisableAllowList: true})
+	gj, err := core.NewGraphJin(conf, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gj.Close()
+
+	// purchases (analog of salesorderdetail) has FKs to BOTH products
+	// (product_id) AND users (customer_id → users.id). Distinct on
+	// product_id then nesting users forces the lateral join to reference
+	// customer_id — which the GROUP BY collapses away, so the inner CTE
+	// no longer projects it. This is the exact shape that emitted
+	// `salesorderdetail_0.salesorderid does not exist` on AdventureWorks.
+	//
+	// Acceptable outcomes after the fix:
+	//   1. Compile-time rejection with a "shape mismatch" error that
+	//      mentions distinct/group-by (preferred — see commentary above).
+	//   2. Successful execution. Less clean since the query is ambiguous,
+	//      but acceptable if the compiler decides to auto-materialize the
+	//      column. We accept either here; we just refuse to ship broken
+	//      SQL that errors out at the database level.
+	gql := `query {
+		purchases(distinct: [product_id], where: { id: { lteq: 100 } }) {
+			product_id
+			sum_quantity
+			users {
+				id
+			}
+		}
+	}`
+
+	res, err := gj.GraphQL(context.Background(), gql, nil, nil)
+	if err != nil {
+		errStr := err.Error()
+		// Accept clean compile-time rejection.
+		if strings.Contains(errStr, "distinct") || strings.Contains(errStr, "group") || strings.Contains(errStr, "shape") {
+			return
+		}
+		// Reject the broken-SQL case the agent saw.
+		t.Fatalf("distinct + aggregate + nested join through non-distinct FK emitted broken SQL (Stage 3 bug): %v", err)
+	}
+
+	var out struct {
+		Purchases []map[string]any `json:"purchases"`
+	}
+	if err := json.Unmarshal(res.Data, &out); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, string(res.Data))
+	}
+	if len(out.Purchases) == 0 {
+		t.Fatal("expected at least one purchase row or a clean compile-time error, got neither")
+	}
 }


### PR DESCRIPTION
## Why this exists

This branch is the response to a detailed agent post-mortem on a failed AdventureWorks query session. The agent ran a "revenue by category" question through GraphJin and ran into multiple silent and misleading failure modes — error messages that pointed at the wrong remediation, a guided-repair tool that returned generic advice on named patterns, example queries from `find_path` that didn't compile, a workflow guide that taught tool order but not query shape, and a composite-FK escape hatch that didn't actually escape.

This PR closes those gaps and fixes the real compiler bug underneath. After deployment, the agent ran additional sessions and reported two more refinements (canonical patterns inviting verbatim `id`/`name` copying, and a generic-classified `field 'id' is not a column` error). Both are now also addressed.

## What an agent sees differently after this PR

**Errors are now actionable, not misleading.** The driver-level `column X does not exist` message is checked against the live schema before being surfaced. When the column actually exists on the table, the error is rewritten to point at `fix_query_error` with a "likely upstream query-shape issue" hint instead of the wrong "use `list_tables`" suggestion. Works dialect-agnostically across postgres, mysql, mariadb, sqlite, oracle, mssql, snowflake, and mongodb.

**The guided repair tool now returns structured repairs, not prose.** `fix_query_error` emits `kind`, `diagnosis`, `repaired_query` (paste-ready GraphQL), and `follow_up_tools` for twelve specific error classes — multi-FK ambiguity, composite-FK ambiguity, distinct+aggregate shape errors, partition-filter requirements, type mismatches, and `field_not_on_table` (the "I copied the pattern verbatim and the table's PK isn't called `id`" case). Small models can read `repaired_query` directly without parsing markdown; frontier models still get the full prose.

**`find_path` validates its own examples and uses real PK column names.** Every generated example query is run through the compiler before being returned. The example uses each step's actual primary key (looked up against the live schema), falling back to `<pk_column>` only when the table can't be resolved. When validation still fails, the response carries a structured warning naming the candidate fix.

**Query shape guidance reaches every agent, not just workflow users.** Three canonical query patterns — metric-by-dimension, time-series, top-N — are surfaced in both `get_workflow_guide` and `get_query_syntax`. Each pattern carries an explicit Wrong/Right contrast. All example column names use placeholder syntax (`<pk_column>`, `<name_column>`, `<date_column>`, `<metric_alias>`, `<numeric_col>`) so small models substitute real column names instead of copying literal `id` and `name` onto tables that have differently-named PKs. A regression test fails the build if a bare `id` or `name` token reappears in any pattern.

**Composite foreign keys have a real escape hatch.** `@through(column: "<any composite col>")` now resolves the full constraint and emits all join conditions, not just the primary one. Verified end-to-end: both columns appear AND'd in the lateral join's WHERE predicate.

**The compiler rejects the wrong-shape query before it produces wrong data.** `distinct: [a] + aggregate + nested join through column b` (where `b` is not in `distinct`) is now a compile-time error with a clear "root the query at the dimension table instead" message — pointing at the metric-by-dimension pattern and `fix_query_error`. The agent's original failure mode (cryptic `column salesorderdetail_0.salesorderid does not exist`) is replaced by an explicit shape-mismatch error at compile time.

**Per-table analytics-mode signals are now first-class.** `get_table_sample` carries a `temporal_filter_warning` when the table has a partition or temporal column under analytics mode, with paste-ready `where:` and `unrestricted: true` alternatives. Agents see the constraint at describe time, not only after a failed execute. The `PartitionFilterRequired` error itself was reformatted to the same scannable multi-option form.

**Aggregation hints are honest about composition limits.** `AggregationInfo.Limitations` lists five known compose-failures (order_by on aggregate aliases, non-root aggregates, nested joins through non-distinct columns, recursive selections with aggregates, MongoDB expression-aggregate gap). Same list every table, repeated per the discovery mode-repetition principle so agents see it wherever they land.

## Bugs found and fixed along the way

**The wrong-shape compiler bug.** Bisecting the agent's failure showed the trigger isn't `sum(expr:)`-specific — any aggregate triggers the same path. The actual rule is "GROUP BY drops a column the nested lateral still references." Now caught at compile time.

**Stage 1b's recursive-FK dedup over-filtered reverse-direction queries.** Multi-FK ambiguity wasn't detected when the query nested in the reverse direction (`{ users { orders { ... } } }` against an orders→users multi-FK). Replaced the column-side filter with OppID-in-bucket dedup. Multi-FK now correctly flagged in both directions.

**`Compiler.FindPath` masked typed errors.** Falling through to `FindCrossDBPath` on any error silently swallowed `*AmbiguousPathError`. Now only falls through on the three genuinely-not-in-graph sentinels.

**`validateExampleQuery` missed compile errors.** `ExplainQuery` reports compile errors via `QueryExplanation.Errors`, not the Go error return. The original validator checked only the latter. Now checks both.

**`find_path` example generator hardcoded `id` for every step.** Caused `field 'id' is not a column or a function` errors against tables with named PKs (AdventureWorks `productcategoryid`, etc.). Now resolves each step's PK against the live schema, falls back to `<pk_column>` only when unresolvable.

## MCP/CLI parity made enforceable

Added `TestMCPCLIParity` and `TestMCPCLIResourceParity` to assert every MCP tool and resource the server exposes has an exact CLI subcommand counterpart. The CLI is the only path users have without an MCP-aware client, so drift here silently strands a capability for those users. Future regressions caught by CI.

## What was deliberately not changed

No new MCP tools were added. Every change enriches an existing tool's response with structured fields, adds validation, or fixes a bug. The `MCPAllToolNames()` registry is unchanged. No directive parser changes. No breaking changes to public API — `core.TableSchema` gains two additive fields, no removals.

## Test plan

- [x] Unit tests across `auth`, `cmd`, `core`, `mongodriver`, `serv`: all green
- [x] Integration tests across postgres, mysql, mariadb, sqlite, oracle, mssql, mongodb: all green via `scripts/test-parallel.sh`
- [x] MCP/CLI parity tests passing
- [x] End-to-end composite-FK SQL emission verified against the in-memory fixture
- [x] Pattern placeholder regression test (no bare `id` / `name` literals in canonical patterns)
- [x] Path-example PK substitution test (real PKs when resolvable, `<pk_column>` placeholder fallback)
- [ ] Snowflake integration tests not run (needs remote credentials)

## Behavior changes worth flagging in CHANGELOG

1. **Distinct + aggregate + nested-join-through-non-distinct-column** is now a compile-time error. Queries that previously produced broken SQL silently now error explicitly. The query was always broken; the error becomes visible earlier.

2. **Multi-FK ambiguity** now errors at compile time instead of silently picking a winner. Deployed users with queries that relied on the silent winner will see an explicit error directing them to add `@through(column:)`.

Saved queries are compiled lazily per request, so deployed instances with unused-but-affected saved queries are not impacted at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)