### PR TITLE
fix(serv): bound shutdown so Ctrl-C exits when SSE/keep-alive conns linger

### DIFF
--- a/serv/serv.go
+++ b/serv/serv.go
@@ -72,14 +72,18 @@ func startHTTP(s1 *HttpService) {
 		sigint := make(chan os.Signal, 1)
 		signal.Notify(sigint, os.Interrupt)
 		<-sigint
+		s.log.Info("shutdown signal received")
 
-		if err := s.srv.Shutdown(context.Background()); err != nil {
-			s.log.Warn("shutdown signal received")
+		// Bounded shutdown: don't wait forever on lingering connections
+		// (e.g. MCP SSE streams or idle keep-alives).
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := s.srv.Shutdown(shutdownCtx); err != nil {
+			s.log.Warnf("graceful shutdown timed out, forcing close: %s", err)
+			s.srv.Close() //nolint:errcheck
 		}
-		close(idleConnsClosed)
-	}()
 
-	s.srv.RegisterOnShutdown(func() {
 		if s.closeFn != nil {
 			s.closeFn()
 		}
@@ -93,7 +97,8 @@ func startHTTP(s1 *HttpService) {
 			}
 		}
 		s.log.Info("shutdown complete")
-	})
+		close(idleConnsClosed)
+	}()
 
 	ver := version
 	// dep := s.conf.name


### PR DESCRIPTION
## Summary
- `s.srv.Shutdown` was called with `context.Background()`, so any in-flight HTTP connection (most commonly an MCP SSE stream at `/api/v1/mcp`, but also idle keep-alives) blocked shutdown forever — Ctrl-C left the process hung.
- `"shutdown complete"` was logged from inside `RegisterOnShutdown`, which fires asynchronously when `Shutdown` is called. The line printed even though the server hadn't actually exited, masking the hang.

## Fix
- Give `Shutdown` a 10s timeout; on timeout fall back to `s.srv.Close()` to force-drop lingering connections.
- Drop `RegisterOnShutdown` and run `closeFn`/cache/db cleanup inline after `Shutdown` returns, so the final `"shutdown complete"` log reflects reality.
- Also added a `"shutdown signal received"` log on SIGINT for visibility.

Single-file change, `serv/serv.go` only.

## Test plan
- [x] `go build ./serv/...` passes
- [x] `go vet ./serv/...` passes
- [ ] Manual: `graphjin serve` against a remote Postgres, open an MCP client (or hold an SSE connection), Ctrl-C — process should exit within ~10s instead of hanging
- [ ] Manual: Ctrl-C with no active clients — process should exit immediately as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)