### PR TITLE
fix(serv): don't trip source-mode validator on viper defaults

### DIFF
--- a/serv/config_test.go
+++ b/serv/config_test.go
@@ -1,6 +1,7 @@
 package serv
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -42,6 +43,7 @@ sources:
 }
 
 func TestSourceModeRejectsLegacyDatabaseSection(t *testing.T) {
+	clearLegacyDatabaseEnv(t)
 	conf, err := NewConfig(`
 sources:
   - name: app
@@ -59,5 +61,67 @@ database:
 	_, err = NewGraphJinService(conf)
 	if err == nil || !strings.Contains(err.Error(), "database is legacy database-only config") {
 		t.Fatalf("expected legacy database rejection, got %v", err)
+	}
+}
+
+// Regression: viper applies database.* defaults (host=localhost,
+// port=5432, type=postgres, ...) on every load. The pre-fix validator
+// inspected the unmarshaled struct and treated those defaults as a
+// user-supplied legacy database, so any sources-only config was
+// wrongly rejected. The validator must only fail when the user
+// actually wrote a `database:` block (or set GJ_DATABASE_* env).
+func TestSourceModeAcceptsSourcesWithoutLegacyDatabase(t *testing.T) {
+	clearLegacyDatabaseEnv(t)
+	conf, err := NewConfig(`
+sources:
+  - name: app
+    kind: sql
+    type: sqlite
+    path: /tmp/app.sqlite
+    default: true
+`, "yaml")
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	if _, err := NewGraphJinService(conf); err != nil {
+		if strings.Contains(err.Error(), "database is legacy database-only config") {
+			t.Fatalf("validator wrongly rejected sources-only config (defaults must not count): %v", err)
+		}
+	}
+}
+
+func TestSourceModeRejectsLegacyDatabaseEnv(t *testing.T) {
+	clearLegacyDatabaseEnv(t)
+	t.Setenv("GJ_DATABASE_HOST", "legacy-host")
+	conf, err := NewConfig(`
+sources:
+  - name: app
+    kind: sql
+    type: sqlite
+    path: /tmp/app.sqlite
+`, "yaml")
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	_, err = NewGraphJinService(conf)
+	if err == nil || !strings.Contains(err.Error(), "database is legacy database-only config") {
+		t.Fatalf("expected legacy database rejection from GJ_DATABASE_* env, got %v", err)
+	}
+}
+
+// clearLegacyDatabaseEnv removes any GJ_DATABASE_* / SJ_DATABASE_* /
+// SG_DATABASE_* values from the process environment for the duration
+// of the test, so a developer's shell can't make these tests flaky.
+func clearLegacyDatabaseEnv(t *testing.T) {
+	t.Helper()
+	for _, e := range os.Environ() {
+		kv := strings.SplitN(e, "=", 2)
+		k := kv[0]
+		if strings.HasPrefix(k, "GJ_DATABASE_") ||
+			strings.HasPrefix(k, "SJ_DATABASE_") ||
+			strings.HasPrefix(k, "SG_DATABASE_") {
+			t.Setenv(k, kv[1])
+			os.Unsetenv(k) //nolint:errcheck
+		}
 	}
 }

--- a/serv/sources.go
+++ b/serv/sources.go
@@ -2,6 +2,7 @@ package serv
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -78,36 +79,34 @@ func validateServiceSourceModeConfig(conf *Config) error {
 		}
 		return conf.Core.ValidateSourceMode()
 	}
-	if (conf.viper != nil && conf.viper.InConfig("database")) || serviceDatabaseConfigured(conf.DB) {
+	if hasUserSuppliedLegacyDatabase(conf) {
 		return fmt.Errorf("database is legacy database-only config; move SQL providers to sources")
 	}
 	return conf.Core.ValidateSourceMode()
 }
 
-func serviceDatabaseConfigured(db Database) bool {
-	return db.ConnString != "" ||
-		db.Type != "" ||
-		db.Host != "" ||
-		db.Port != 0 ||
-		db.DBName != "" ||
-		db.User != "" ||
-		db.Password != "" ||
-		db.Schema != "" ||
-		db.Path != "" ||
-		db.MaxConnections != 0 ||
-		db.MaxConnIdleTime != 0 ||
-		db.MaxConnLifeTime != 0 ||
-		db.PingTimeout != 0 ||
-		db.EnableTLS ||
-		db.ServerName != "" ||
-		db.ServerCert != "" ||
-		db.ClientCert != "" ||
-		db.ClientKey != "" ||
-		db.Encrypt != nil ||
-		db.TrustServerCertificate != nil ||
-		db.PrivateKeyPath != "" ||
-		db.PrivateKeyPEM != "" ||
-		db.KeyPassphrase != ""
+// hasUserSuppliedLegacyDatabase reports whether the user has explicitly
+// configured a top-level legacy `database:` provider — either via the
+// YAML config file or via GJ_DATABASE_* / SJ_DATABASE_* / SG_DATABASE_*
+// environment variables. Defaults baked into the viper instance by
+// newViperWithDefaults are intentionally ignored: they are not user
+// intent and would otherwise cause every source-mode config to be
+// wrongly rejected.
+func hasUserSuppliedLegacyDatabase(conf *Config) bool {
+	if conf == nil {
+		return false
+	}
+	if conf.viper != nil && conf.viper.InConfig("database") {
+		return true
+	}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "GJ_DATABASE_") ||
+			strings.HasPrefix(e, "SJ_DATABASE_") ||
+			strings.HasPrefix(e, "SG_DATABASE_") {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeServiceSources(conf *Config) error {


### PR DESCRIPTION
## Summary

`newViperWithDefaults` seeds `database.host=localhost`, `database.port=5432`, `database.type=postgres`, `database.user=postgres`, `database.schema=public`, `database.pool_size=10` on every config load (`serv/config.go:606-612`). The source-mode validator at `serv/sources.go:81` then inspected the unmarshaled `conf.DB` struct via `serviceDatabaseConfigured`, which can't tell defaults from user intent — so any sources-only YAML was rejected with:

> `database is legacy database-only config; move SQL providers to sources`

even when no `database:` block was present.

### Reproduction

A minimal `dev.yml`:

```yaml
sources:
  - name: app
    kind: sql
    type: postgres
    connection_string: postgres://postgres:postgres@localhost:5432/app
    default: true
```

…fails to start with the legacy-rejection error, despite matching the canonical example in `CONFIG.md` Sources Mode.

### Fix

Replace the struct check with `hasUserSuppliedLegacyDatabase`, which only flags genuine user input:

- an explicit `database:` key in the config file (`viper.InConfig("database")`), or
- a `GJ_DATABASE_*` / `SJ_DATABASE_*` / `SG_DATABASE_*` environment variable

The unused `serviceDatabaseConfigured` helper is removed.

### Why the existing test didn't catch this

`TestSourceModeRejectsLegacyDatabaseSection` uses `NewConfig(...)` + `NewGraphJinService(...)`, which goes through `newViperWithDefaults`. The test passed because the same legacy-rejection message fires whether the cause is the explicit `database:` block in the YAML or just the defaulted struct — so the error-string assertion was satisfied for the wrong reason.

## Test plan

- [x] New `TestSourceModeAcceptsSourcesWithoutLegacyDatabase` — pins the regression: sources-only YAML must load past the validator.
- [x] New `TestSourceModeRejectsLegacyDatabaseEnv` — covers the env-var path so we don't regress legitimate legacy-env rejection.
- [x] Existing `TestSourceModeRejectsLegacyDatabaseSection` still passes.
- [x] Verified manually by rebuilding \`./bin/graphjin\` and starting it against the sources-mode \`dev.yml\` above — boots cleanly in source mode (previously: fatal on startup).

\`\`\`
=== RUN   TestSourceModeRejectsLegacyDatabaseSection
--- PASS: TestSourceModeRejectsLegacyDatabaseSection (0.00s)
=== RUN   TestSourceModeAcceptsSourcesWithoutLegacyDatabase
--- PASS: TestSourceModeAcceptsSourcesWithoutLegacyDatabase (0.00s)
=== RUN   TestSourceModeRejectsLegacyDatabaseEnv
--- PASS: TestSourceModeRejectsLegacyDatabaseEnv (0.00s)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)