### PR TITLE
Wire col-ref operands through MariaDB, MSSQL, and MongoDB renderers

### DIFF
--- a/core/internal/dialect/dialect.go
+++ b/core/internal/dialect/dialect.go
@@ -28,6 +28,7 @@ type Context interface {
 	RenderExp(ti sdata.DBTable, ex *qcode.Exp)
 	GetStaticVar(name string) (string, bool) // Get config-level variable
 	GetSecPrefix() string                    // Get security prefix for cursor encryption
+	SetError(err error)                      // Surface a render-time error
 }
 
 // InlineChildRenderer is passed to dialects for rendering inline children

--- a/core/internal/dialect/mariadb.go
+++ b/core/internal/dialect/mariadb.go
@@ -1475,7 +1475,9 @@ func (d *MariaDBDialect) renderExp(ctx Context, r InlineChildRenderer, psel, sel
 		ctx.WriteString(` (`)
 
 		// Render right side
-		if ex.Right.Col.Name != "" {
+		if ex.Right.ValType == qcode.ValRef {
+			d.renderColRefRight(ctx, r, sel, ex)
+		} else if ex.Right.Col.Name != "" {
 			// Check for cursor CTE reference first
 			// qcode sets ex.Right.Table = "__cur" for cursor pagination filters
 			if ex.Right.Table == "__cur" {
@@ -2600,4 +2602,80 @@ func (d *MariaDBDialect) RequiresNullOnEmptySelect() bool {
 	return true // MariaDB needs NULL when no columns rendered
 }
 
+// renderColRefRight emits a same-table column reference or a multi-hop
+// belongs-to correlated subquery for the right operand.
+func (d *MariaDBDialect) renderColRefRight(ctx Context, r InlineChildRenderer, sel *qcode.Select, ex *qcode.Exp) {
+	if len(ex.Right.RelPath) == 0 {
+		t := ex.Right.Col.Table
+		if t == sel.Ti.Name && sel.ID >= 0 {
+			t = fmt.Sprintf("%s_%d", t, sel.ID)
+		}
+		r.ColWithTable(t, ex.Right.Col.Name)
+		return
+	}
+
+	path := ex.Right.RelPath
+	closeParens := len(path)
+
+	lastHop := path[len(path)-1]
+	ctx.WriteString(`SELECT `)
+	r.ColWithTable(ex.Right.Col.Table, ex.Right.Col.Name)
+	ctx.WriteString(` FROM `)
+	d.writeQualifiedTable(ctx, lastHop.Right.Ti)
+	ctx.WriteString(` WHERE `)
+	r.ColWithTable(lastHop.Right.Col.Table, lastHop.Right.Col.Name)
+	ctx.WriteString(` = `)
+
+	for i := len(path) - 2; i >= 0; i-- {
+		hop := path[i]
+		outerHop := path[i+1]
+		ctx.WriteString(`(SELECT `)
+		r.ColWithTable(outerHop.Left.Col.Table, outerHop.Left.Col.Name)
+		ctx.WriteString(` FROM `)
+		d.writeQualifiedTable(ctx, hop.Right.Ti)
+		ctx.WriteString(` WHERE `)
+		r.ColWithTable(hop.Right.Col.Table, hop.Right.Col.Name)
+		ctx.WriteString(` = `)
+		if i > 0 {
+			continue
+		}
+		d.writeOuterColRefMariaDB(ctx, r, sel, hop.Left.Col)
+		for _, pair := range hop.ExtraPairs {
+			ctx.WriteString(` AND `)
+			r.ColWithTable(pair.R.Table, pair.R.Name)
+			ctx.WriteString(` = `)
+			d.writeOuterColRefMariaDB(ctx, r, sel, pair.L)
+		}
+	}
+
+	if len(path) == 1 {
+		d.writeOuterColRefMariaDB(ctx, r, sel, path[0].Left.Col)
+		for _, pair := range path[0].ExtraPairs {
+			ctx.WriteString(` AND `)
+			r.ColWithTable(pair.R.Table, pair.R.Name)
+			ctx.WriteString(` = `)
+			d.writeOuterColRefMariaDB(ctx, r, sel, pair.L)
+		}
+	}
+
+	for i := 1; i < closeParens; i++ {
+		ctx.WriteString(`)`)
+	}
+}
+
+func (d *MariaDBDialect) writeQualifiedTable(ctx Context, ti sdata.DBTable) {
+	if ti.Schema != "" {
+		ctx.Quote(ti.Schema)
+		ctx.WriteString(`.`)
+	}
+	ctx.Quote(ti.Name)
+}
+
+func (d *MariaDBDialect) writeOuterColRefMariaDB(ctx Context, r InlineChildRenderer, sel *qcode.Select, col sdata.DBColumn) {
+	t := col.Table
+	if sel != nil && t == sel.Ti.Name && sel.ID >= 0 {
+		t = fmt.Sprintf("%s_%d", t, sel.ID)
+	}
+	r.ColWithTable(t, col.Name)
+}
 

--- a/core/internal/dialect/mongodb.go
+++ b/core/internal/dialect/mongodb.go
@@ -2981,6 +2981,20 @@ func (d *MongoDBDialect) renderRecursiveWhereCondition(ctx Context, exp *qcode.E
 
 // renderRecursiveComparisonValue renders a value for comparison in recursive where
 func (d *MongoDBDialect) renderRecursiveComparisonValue(ctx Context, exp *qcode.Exp) {
+	if exp.Right.ValType == qcode.ValRef {
+		if len(exp.Right.RelPath) > 0 {
+			ctx.SetError(fmt.Errorf("mongodb: cross-table column reference operands in recursive lookups are not supported"))
+			return
+		}
+		rightName := exp.Right.Col.Name
+		if rightName == "id" {
+			rightName = "_id"
+		}
+		ctx.WriteString(`"$$item.`)
+		ctx.WriteString(rightName)
+		ctx.WriteString(`"`)
+		return
+	}
 	if exp.Right.ValType == qcode.ValVar {
 		ctx.AddParam(Param{Name: exp.Right.Val, Type: "any"})
 	} else {
@@ -3833,6 +3847,11 @@ func (d *MongoDBDialect) renderExpression(ctx Context, exp *qcode.Exp) {
 		}
 		d.RenderGeoOp(ctx, "", colName, exp)
 	default:
+		if exp.Right.ValType == qcode.ValRef {
+			d.renderColRefExpression(ctx, exp)
+			return
+		}
+
 		// Simple comparison: field op value
 		colName := exp.Left.Col.Name
 		if colName == "" {
@@ -3857,6 +3876,55 @@ func (d *MongoDBDialect) renderExpression(ctx Context, exp *qcode.Exp) {
 
 		d.renderComparisonValue(ctx, exp)
 	}
+}
+
+// renderColRefExpression emits a same-collection column comparison via $expr.
+// Multi-hop belongs-to comparisons are not supported on MongoDB without
+// pre-injecting a $lookup stage in the pipeline, which is outside the scope
+// of the WHERE-clause renderer; reject those at compile time.
+func (d *MongoDBDialect) renderColRefExpression(ctx Context, exp *qcode.Exp) {
+	if len(exp.Right.RelPath) > 0 {
+		ctx.SetError(fmt.Errorf("mongodb: cross-table column reference operands (multi-hop) are not supported; use a same-collection column reference instead"))
+		return
+	}
+	op, ok := colRefMongoOp(exp.Op)
+	if !ok {
+		ctx.SetError(fmt.Errorf("mongodb: operator %s does not support column reference operands", exp.Op))
+		return
+	}
+	leftName := exp.Left.Col.Name
+	if leftName == "id" {
+		leftName = "_id"
+	}
+	rightName := exp.Right.Col.Name
+	if rightName == "id" {
+		rightName = "_id"
+	}
+	ctx.WriteString(`"$expr":{"`)
+	ctx.WriteString(op)
+	ctx.WriteString(`":["$`)
+	ctx.WriteString(leftName)
+	ctx.WriteString(`","$`)
+	ctx.WriteString(rightName)
+	ctx.WriteString(`"]}`)
+}
+
+func colRefMongoOp(op qcode.ExpOp) (string, bool) {
+	switch op {
+	case qcode.OpEquals:
+		return "$eq", true
+	case qcode.OpNotEquals:
+		return "$ne", true
+	case qcode.OpGreaterThan:
+		return "$gt", true
+	case qcode.OpGreaterOrEquals:
+		return "$gte", true
+	case qcode.OpLesserThan:
+		return "$lt", true
+	case qcode.OpLesserOrEquals:
+		return "$lte", true
+	}
+	return "", false
 }
 
 // renderComparisonValue renders the right side of a comparison

--- a/core/internal/dialect/mssql.go
+++ b/core/internal/dialect/mssql.go
@@ -2359,6 +2359,10 @@ func (d *MSSQLDialect) renderColumn(ctx Context, r InlineChildRenderer, psel, se
 }
 
 func (d *MSSQLDialect) renderValue(ctx Context, r InlineChildRenderer, psel, sel *qcode.Select, ex *qcode.Exp) {
+	if ex.Right.ValType == qcode.ValRef {
+		d.renderColRefRight(ctx, r, sel, ex)
+		return
+	}
 	// Handle column references (for relationship joins)
 	if ex.Right.Col.Name != "" {
 		var table string
@@ -3740,4 +3744,81 @@ func (d *MSSQLDialect) RequiresJSONQueryWrapper() bool {
 
 func (d *MSSQLDialect) RequiresNullOnEmptySelect() bool {
 	return false // MSSQL doesn't need NULL when no columns rendered
+}
+
+// renderColRefRight emits a same-table column reference or a multi-hop
+// belongs-to correlated subquery for the right operand.
+func (d *MSSQLDialect) renderColRefRight(ctx Context, r InlineChildRenderer, sel *qcode.Select, ex *qcode.Exp) {
+	if len(ex.Right.RelPath) == 0 {
+		t := ex.Right.Col.Table
+		if t == sel.Ti.Name && sel.ID >= 0 {
+			t = fmt.Sprintf("%s_%d", t, sel.ID)
+		}
+		r.ColWithTable(t, ex.Right.Col.Name)
+		return
+	}
+
+	path := ex.Right.RelPath
+	closeParens := len(path)
+
+	lastHop := path[len(path)-1]
+	ctx.WriteString(`(SELECT `)
+	r.ColWithTable(ex.Right.Col.Table, ex.Right.Col.Name)
+	ctx.WriteString(` FROM `)
+	d.writeQualifiedTableMSSQL(ctx, lastHop.Right.Ti)
+	ctx.WriteString(` WHERE `)
+	r.ColWithTable(lastHop.Right.Col.Table, lastHop.Right.Col.Name)
+	ctx.WriteString(` = `)
+
+	for i := len(path) - 2; i >= 0; i-- {
+		hop := path[i]
+		outerHop := path[i+1]
+		ctx.WriteString(`(SELECT `)
+		r.ColWithTable(outerHop.Left.Col.Table, outerHop.Left.Col.Name)
+		ctx.WriteString(` FROM `)
+		d.writeQualifiedTableMSSQL(ctx, hop.Right.Ti)
+		ctx.WriteString(` WHERE `)
+		r.ColWithTable(hop.Right.Col.Table, hop.Right.Col.Name)
+		ctx.WriteString(` = `)
+		if i > 0 {
+			continue
+		}
+		d.writeOuterColRefMSSQL(ctx, r, sel, hop.Left.Col)
+		for _, pair := range hop.ExtraPairs {
+			ctx.WriteString(` AND `)
+			r.ColWithTable(pair.R.Table, pair.R.Name)
+			ctx.WriteString(` = `)
+			d.writeOuterColRefMSSQL(ctx, r, sel, pair.L)
+		}
+	}
+
+	if len(path) == 1 {
+		d.writeOuterColRefMSSQL(ctx, r, sel, path[0].Left.Col)
+		for _, pair := range path[0].ExtraPairs {
+			ctx.WriteString(` AND `)
+			r.ColWithTable(pair.R.Table, pair.R.Name)
+			ctx.WriteString(` = `)
+			d.writeOuterColRefMSSQL(ctx, r, sel, pair.L)
+		}
+	}
+
+	for i := 0; i < closeParens; i++ {
+		ctx.WriteString(`)`)
+	}
+}
+
+func (d *MSSQLDialect) writeQualifiedTableMSSQL(ctx Context, ti sdata.DBTable) {
+	if ti.Schema != "" {
+		ctx.Quote(ti.Schema)
+		ctx.WriteString(`.`)
+	}
+	ctx.Quote(ti.Name)
+}
+
+func (d *MSSQLDialect) writeOuterColRefMSSQL(ctx Context, r InlineChildRenderer, sel *qcode.Select, col sdata.DBColumn) {
+	t := col.Table
+	if sel != nil && t == sel.Ti.Name && sel.ID >= 0 {
+		t = fmt.Sprintf("%s_%d", t, sel.ID)
+	}
+	r.ColWithTable(t, col.Name)
 }

--- a/core/internal/psql/colref_dialects_test.go
+++ b/core/internal/psql/colref_dialects_test.go
@@ -1,0 +1,159 @@
+package psql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dosco/graphjin/core/v3/internal/psql"
+	"github.com/dosco/graphjin/core/v3/internal/qcode"
+	"github.com/dosco/graphjin/core/v3/internal/sdata"
+)
+
+func newDialectCompilers(t *testing.T, dbType string) (*qcode.Compiler, *psql.Compiler) {
+	t.Helper()
+	schema, err := sdata.GetTestSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	qc, err := qcode.NewCompiler(schema, qcode.Config{DBSchema: schema.DBSchema()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := qc.AddRole("user", "public", "products", qcode.TRConfig{
+		Query: qcode.QueryConfig{
+			Columns: []string{"id", "name", "price", "user_id", "users"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := qc.AddRole("user", "public", "users", qcode.TRConfig{
+		Query: qcode.QueryConfig{
+			Columns: []string{"id", "full_name", "email", "products"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pc := psql.NewCompiler(psql.Config{DBType: dbType})
+	return qc, pc
+}
+
+func compileWith(t *testing.T, qc *qcode.Compiler, pc *psql.Compiler, gql string) string {
+	t.Helper()
+	reqQC, err := qc.Compile([]byte(gql), nil, "user", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, sqlBytes, err := pc.CompileEx(reqQC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(sqlBytes)
+}
+
+func TestColRefOperand_MongoDB_SameCollection(t *testing.T) {
+	qc, pc := newDialectCompilers(t, "mongodb")
+	gql := `query {
+		products(where: { price: { lt: { col: "id" } } }) {
+			id
+		}
+	}`
+	sql := compileWith(t, qc, pc, gql)
+	want := `"$expr":{"$lt":["$price","$_id"]}`
+	if !strings.Contains(sql, want) {
+		t.Fatalf("[mongodb] expected %q in output; got:\n%s", want, sql)
+	}
+}
+
+func TestColRefOperand_MongoDB_RejectsMultiHop(t *testing.T) {
+	qc, pc := newDialectCompilers(t, "mongodb")
+	gql := `query {
+		products(where: { user_id: { eq: { col: "users.id" } } }) {
+			id
+		}
+	}`
+	reqQC, err := qc.Compile([]byte(gql), nil, "user", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = pc.CompileEx(reqQC)
+	if err == nil {
+		t.Fatal("expected compile error for mongodb multi-hop col-ref, got nil")
+	}
+	if !strings.Contains(err.Error(), "mongodb") || !strings.Contains(err.Error(), "multi-hop") {
+		t.Fatalf("expected mongodb-specific multi-hop rejection, got: %v", err)
+	}
+}
+
+func TestColRefOperand_AllSQLDialects(t *testing.T) {
+	sameTable := `query {
+		products(where: { price: { lt: { col: "id" } } }) {
+			id
+		}
+	}`
+	belongsTo := `query {
+		products(where: { user_id: { eq: { col: "users.id" } } }) {
+			id
+		}
+	}`
+
+	cases := []struct {
+		dbType            string
+		sameTableSubstr   string // exact substring expected in the WHERE
+		belongsToSubstr   string // exact substring expected (correlated subquery)
+	}{
+		{
+			dbType:          "postgres",
+			sameTableSubstr: `("products"."price") < ("products"."id")`,
+			belongsToSubstr: `(SELECT "users"."id" FROM "public"."users" WHERE "users"."id" = "products"."user_id")`,
+		},
+		{
+			dbType:          "mysql",
+			sameTableSubstr: "(`products`.`price`) < (`products`.`id`)",
+			belongsToSubstr: "(SELECT `users`.`id` FROM `public`.`users` WHERE `users`.`id` = `products`.`user_id`)",
+		},
+		{
+			dbType:          "mariadb",
+			sameTableSubstr: "(`products_0`.`price`) < (`products_0`.`id`)",
+			belongsToSubstr: "(SELECT `users`.`id` FROM `public`.`users` WHERE `users`.`id` = `products_0`.`user_id`)",
+		},
+		{
+			dbType:          "sqlite",
+			sameTableSubstr: `("products"."price") < ("products"."id")`,
+			belongsToSubstr: `(SELECT "users"."id" FROM "public"."users" WHERE "users"."id" = "products"."user_id")`,
+		},
+		{
+			dbType:          "mssql",
+			sameTableSubstr: `([products_0].[price] < [products_0].[id])`,
+			belongsToSubstr: `(SELECT [users].[id] FROM [public].[users] WHERE [users].[id] = [products_0].[user_id])`,
+		},
+		{
+			dbType:          "oracle",
+			sameTableSubstr: `("PRODUCTS"."PRICE") < ("PRODUCTS"."ID")`,
+			belongsToSubstr: `(SELECT "USERS"."ID" FROM "PUBLIC"."USERS" WHERE "USERS"."ID" = "PRODUCTS"."USER_ID")`,
+		},
+		{
+			dbType:          "snowflake",
+			sameTableSubstr: `("products"."price") < ("products"."id")`,
+			belongsToSubstr: `(SELECT "users"."id" FROM "public"."users" WHERE "users"."id" = "products"."user_id")`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.dbType+"_same_table", func(t *testing.T) {
+			qc, pc := newDialectCompilers(t, tc.dbType)
+			sql := compileWith(t, qc, pc, sameTable)
+			if !strings.Contains(sql, tc.sameTableSubstr) {
+				t.Fatalf("[%s] expected %q in SQL; got:\n%s", tc.dbType, tc.sameTableSubstr, sql)
+			}
+		})
+
+		t.Run(tc.dbType+"_belongs_to", func(t *testing.T) {
+			qc, pc := newDialectCompilers(t, tc.dbType)
+			sql := compileWith(t, qc, pc, belongsTo)
+			if !strings.Contains(sql, tc.belongsToSubstr) {
+				t.Fatalf("[%s] expected %q in SQL; got:\n%s", tc.dbType, tc.belongsToSubstr, sql)
+			}
+		})
+	}
+}

--- a/core/internal/psql/util.go
+++ b/core/internal/psql/util.go
@@ -82,6 +82,12 @@ func (c *compilerContext) Quote(s string) {
 	c.quoted(s)
 }
 
+func (c *compilerContext) SetError(err error) {
+	if c.err == nil {
+		c.err = err
+	}
+}
+
 func (c *compilerContext) ColWithTable(table, col string) {
 	c.colWithTable(table, col)
 }

--- a/core/subs.go
+++ b/core/subs.go
@@ -801,6 +801,9 @@ func (c *stringContext) GetSecPrefix() string                    { return "" }
 func (c *stringContext) RenderExp(ti sdata.DBTable, ex *qcode.Exp) {
 	// Not implemented for stringContext - only used for subscription unboxing
 }
+func (c *stringContext) SetError(err error) {
+	// stringContext is fire-and-forget; no error path
+}
 
 // renderJSONArray function is called on the graphjin struct to render a json array.
 func renderJSONArray(v []json.RawMessage) json.RawMessage {


### PR DESCRIPTION
## Summary
Follow-up to #591. The first PR added the col-ref operand syntax (`{ <op>: { col: \"<name>\" } }`) but I only verified it against PostgreSQL. This PR extends and tests the feature across all 8 dialects.

### What CI on #591 actually proved (vs. didn't)
- ✅ No regression on any dialect (the shared `renderExp` plumbing is benign for queries that don't use col-ref).
- ❌ Did NOT prove col-ref itself works on dialects other than Postgres. The col-ref unit tests defaulted to Postgres.

### What this PR adds
**MariaDB & MSSQL** have their own complete WHERE renderers (not the shared `psql/exp.go` path) because they emit inline-JSON child queries instead of LATERAL joins. Before this PR, col-ref operand on those dialects produced wrong SQL — `(products_0.user_id = users_0.id)` (referencing a `users_0` alias that doesn't exist) instead of the correlated subquery `(products_0.user_id = (SELECT users.id FROM public.users WHERE users.id = products_0.user_id))`. New `renderColRefRight` helper on each dialect emits the proper shape.

**MongoDB** uses `CompileFullQuery` (its own JSON DSL renderer), completely bypassing the SQL renderer. Same-collection col-ref now emits `$expr` with field references:
```json
{ "$expr": { "$lt": ["$price", "$_id"] } }
```
Multi-hop belongs-to col-ref on MongoDB would require injecting a `$lookup` stage into the pipeline — significant pipeline refactoring outside the WHERE renderer's scope. **Rejected at compile time with a clear error** so users get fast feedback instead of silently broken queries.

**New `Context.SetError(err error)`** on the dialect Context interface so dialect-side renderers can surface compile-time errors (MongoDB uses this for the multi-hop rejection).

### Coverage matrix (all in this PR)
| Dialect | Same-collection | Multi-hop belongs-to |
|---|---|---|
| postgres | ✅ tested | ✅ tested |
| mysql | ✅ tested | ✅ tested |
| mariadb | ✅ tested | ✅ tested (this PR fixes) |
| sqlite | ✅ tested | ✅ tested |
| mssql | ✅ tested | ✅ tested (this PR fixes) |
| oracle | ✅ tested | ✅ tested |
| snowflake | ✅ tested | ✅ tested |
| mongodb | ✅ tested ($expr) | ❌ rejected with clear error |

## Test plan
- [x] New `colref_dialects_test.go` — exact SQL substring assertions for all 7 SQL dialects (same-table + belongs-to)
- [x] New MongoDB tests — `$expr` shape on same-collection, error message on multi-hop
- [x] `go test ./core/...` — all 14 dialect cases pass; full core test suite passes
- [ ] Full CI matrix on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)