### PR TITLE
Fix /health 500 in sources mode: default the ping timeout

### DIFF
--- a/serv/health.go
+++ b/serv/health.go
@@ -3,6 +3,7 @@ package serv
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -10,11 +11,22 @@ import (
 
 var healthyResponse = []byte("All's Well")
 
+// defaultHealthPingTimeout bounds the health probe when no ping_timeout is
+// configured. In sources mode the legacy DB block is never populated, so
+// conf.DB.PingTimeout is zero — without this guard the probe context is
+// born expired and /health returns 500 (context deadline exceeded) while
+// queries serve fine.
+const defaultHealthPingTimeout = 5 * time.Second
+
 // healthCheckHandler returns a handler that checks the health of the service
 func healthCheckHandler(s1 *HttpService) http.Handler {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		s := s1.Load().(*graphjinService)
-		c, cancel := context.WithTimeout(r.Context(), s.conf.DB.PingTimeout)
+		pingTimeout := s.conf.DB.PingTimeout
+		if pingTimeout <= 0 {
+			pingTimeout = defaultHealthPingTimeout
+		}
+		c, cancel := context.WithTimeout(r.Context(), pingTimeout)
 		defer cancel()
 
 		c1, span := s.spanStart(c, "Health Check Request")
@@ -31,6 +43,8 @@ func healthCheckHandler(s1 *HttpService) http.Handler {
 
 			s.zlog.Error("Health Check", []zapcore.Field{zap.Error(err)}...)
 			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("database ping failed"))
+			return
 		}
 
 		_, _ = w.Write(healthyResponse)


### PR DESCRIPTION
The health handler used `conf.DB.PingTimeout` directly as its context deadline. In sources mode the legacy `DB` block is never populated, so the timeout was zero — the probe context was born expired and `/health` returned 500 (`context deadline exceeded`) on every request while queries served fine. Orchestrator healthchecks (compose, k8s probes) key off this endpoint, so a sources-mode deployment looked permanently unhealthy.

Default the probe to 5s when unset, matching the 30s fallback the connect path already applies (`serv/init.go`), and stop appending `All's Well` to the 500 response body.

Reproduced and verified against a live sources-mode server (`auth: jwt`, postgres source): before — `/health` 500 ×N with `context deadline exceeded` logged; after — `All's Well` 200 consistently, queries unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)