### PR TITLE
fix(serv): don't persist a legacy database block in sources mode (#601)

### DIFF
--- a/serv/mcp_config.go
+++ b/serv/mcp_config.go
@@ -3621,6 +3621,26 @@ func (ms *mcpServer) saveConfigToDisk() error {
 	// Sync current config state to viper
 	ms.syncConfigToViper(v)
 
+	// In sources mode the viper tree still carries defaulted legacy keys
+	// (database/metadata/catalog/filesystems/openapi) that were never on
+	// disk. WriteConfig would serialize them and the next reload rejects
+	// them via validateIsSourcesUsed. Write a sanitized copy instead.
+	if ms.service.conf.Core.IsSourcesUsed() {
+		settings := v.AllSettings()
+		for _, k := range []string{"database", "databases", "metadata", "catalog", "filesystems", "openapi", "openapi_specs_dir"} {
+			delete(settings, k)
+		}
+		nv := viper.New()
+		nv.SetConfigFile(v.ConfigFileUsed())
+		if err := nv.MergeConfigMap(settings); err != nil {
+			return fmt.Errorf("failed to stage sanitized config: %w", err)
+		}
+		if err := nv.WriteConfig(); err != nil {
+			return fmt.Errorf("failed to write config: %w", err)
+		}
+		return nil
+	}
+
 	// Write the config file
 	if err := v.WriteConfig(); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)


### PR DESCRIPTION
## What

Fixes #601. In sources mode, a successful `gj_config.update { mode: "apply" }` wrote a config file that could not be reloaded.

`saveConfigToDisk` synced sources into viper and then called `v.WriteConfig()`, which serializes the **entire** viper tree — including the defaulted `database.*` keys (`serv/config.go` `SetDefault`) that were never in the on-disk config. The saved file then carried a spurious top-level `database:` block, and the next reload (`reload_on_config_change`) or restart rejected it via `Config.validateIsSourcesUsed` ("databases is legacy database-only config"), **crash-looping the engine** after any config apply. Even a minimal `source_patches` edit triggered it.

## Fix

When `IsSourcesUsed()`, write a sanitized copy: drop the `database`/`databases`/`metadata`/`catalog`/`filesystems`/`openapi` keys from `AllSettings()` and `WriteConfig` through a fresh viper bound to the same file. A config written by `gj_config.update` now round-trips cleanly through a reload.

## Test

Verified live against a sources-mode engine (`reload_on_config_change: true`): `set_source_access` (`source_patches`), `register_source` (`update_sources`), and `add_role` (`roles`) each preview→apply, the watcher reloads the saved file, and the engine stays up (health 200) with auth intact and the meta-source preserved — where before each apply FATAL'd on reload. The saved `dev.yml` no longer contains a top-level `database:` block.