### PR TITLE
fix(mssql): consistent table-name normalization + variable/nested LIMIT

### DIFF
--- a/core/internal/dialect/mssql.go
+++ b/core/internal/dialect/mssql.go
@@ -32,13 +32,15 @@ import (
 //   - Transaction support
 //   - Inline bulk inserts
 //
+// # Requirements
+//
+// Targets SQL Server 2017+ and database COMPATIBILITY_LEVEL >= 130. The
+// OPENJSON-based paths (variable inserts, variable IN filters, JSON array
+// columns) fail with a parser error on lower compatibility levels.
+//
 // # Known Limitations
 //
 // The following features are not yet fully implemented for MSSQL:
-//
-// ## Nested/Related Table Mutations
-// Mutations involving related tables fail with "t.id could not be bound".
-// The table alias reference pattern used for nested inserts needs MSSQL-specific handling.
 //
 // ## Functions
 // Table-returning functions and field functions are not discovered from schema.
@@ -47,10 +49,6 @@ import (
 // ## Array Columns
 // MSSQL does not have native array column support like PostgreSQL.
 // WHERE IN with array columns fails.
-//
-// ## Cursor Pagination
-// Cursor pagination fails with "Invalid object name '__cur'".
-// The cursor CTE implementation needs MSSQL-specific syntax.
 //
 // ## Subscriptions
 // Real-time subscriptions are not yet implemented for MSSQL.
@@ -68,9 +66,6 @@ import (
 //
 // ## Polymorphic Relationships (Unions)
 // Union type queries are not yet fully working.
-//
-// ## Variable LIMIT
-// Dynamic LIMIT from variables may not apply correctly.
 //
 // ## Skip/Include Directives
 // Some skip/include directive patterns fail.
@@ -1044,6 +1039,12 @@ func (d *MSSQLDialect) RenderInlineChild(ctx Context, r InlineChildRenderer, pse
 				}
 			}
 
+			// Apply child paging (OFFSET/FETCH); RenderLimit adds the
+			// ORDER BY (SELECT NULL) fallback MSSQL requires when none is set.
+			if sel.Paging.Limit != 0 || sel.Paging.LimitVar != "" {
+				r.RenderLimit(sel)
+			}
+
 			ctx.WriteString(` FOR JSON PATH, INCLUDE_NULL_VALUES), '[]')`)
 		}
 	} else {
@@ -1083,7 +1084,7 @@ func (d *MSSQLDialect) RenderInlineChild(ctx Context, r InlineChildRenderer, pse
 				}
 				// Render ORDER BY and OFFSET/FETCH inside the subquery
 				d.renderOrderBy(ctx, r, sel, "")
-				if sel.Paging.Limit != 0 {
+				if sel.Paging.Limit != 0 || sel.Paging.LimitVar != "" {
 					r.RenderLimit(sel)
 				}
 				ctx.WriteString(`) AS __rows)`)
@@ -1125,7 +1126,7 @@ func (d *MSSQLDialect) RenderInlineChild(ctx Context, r InlineChildRenderer, pse
 				}
 				d.renderGroupBy(ctx, r, sel)
 				d.renderOrderBy(ctx, r, sel, "")
-				if sel.Paging.Limit != 0 {
+				if sel.Paging.Limit != 0 || sel.Paging.LimitVar != "" {
 					r.RenderLimit(sel)
 				}
 				ctx.WriteString(` FOR JSON PATH, INCLUDE_NULL_VALUES), '[]')) AS [json], `)
@@ -1218,7 +1219,7 @@ func (d *MSSQLDialect) RenderInlineChild(ctx Context, r InlineChildRenderer, pse
 				d.renderOrderBy(ctx, r, sel, "")
 
 				// Render OFFSET/FETCH
-				if sel.Paging.Limit != 0 {
+				if sel.Paging.Limit != 0 || sel.Paging.LimitVar != "" {
 					r.RenderLimit(sel)
 				}
 

--- a/core/internal/introspection/tables.go
+++ b/core/internal/introspection/tables.go
@@ -723,10 +723,10 @@ func scanDiscoveredColumnRows(rows *sql.Rows, dbtype string, blockList []string,
 
 		if dbtype == "sqlite" || dbtype == "oracle" || dbtype == "mssql" || dbtype == "snowflake" || dbtype == "bigquery" || dbtype == "redshift" {
 			c.Name = util.ToSnake(c.Name)
-			c.Table = strings.ToLower(c.Table)
+			c.Table = util.ToSnake(c.Table)
 			c.Schema = strings.ToLower(c.Schema)
 			c.Type = strings.ToLower(c.Type)
-			c.FKeyTable = strings.ToLower(c.FKeyTable)
+			c.FKeyTable = util.ToSnake(c.FKeyTable)
 			c.FKeySchema = strings.ToLower(c.FKeySchema)
 			c.FKeyCol = util.ToSnake(c.FKeyCol)
 		}
@@ -1354,9 +1354,9 @@ func discoverCompositeFKsCSV(ctx context.Context, db *sql.DB, dbtype, query stri
 
 		if normalize {
 			info.Schema = strings.ToLower(info.Schema)
-			info.Table = strings.ToLower(info.Table)
+			info.Table = util.ToSnake(info.Table)
 			info.FKeySchema = strings.ToLower(info.FKeySchema)
-			info.FKeyTable = strings.ToLower(info.FKeyTable)
+			info.FKeyTable = util.ToSnake(info.FKeyTable)
 			for i := range info.LocalCols {
 				info.LocalCols[i] = strings.ToLower(util.ToSnake(strings.TrimSpace(info.LocalCols[i])))
 			}
@@ -1563,9 +1563,9 @@ func discoverSnowflakeCompositeFKsViaShow(ctx context.Context, db *sql.DB) ([]Co
 		info.LocalCols = strings.Split(localCSV, ",")
 		info.FKeyCols = strings.Split(fkeyCSV, ",")
 		info.Schema = strings.ToLower(info.Schema)
-		info.Table = strings.ToLower(info.Table)
+		info.Table = util.ToSnake(info.Table)
 		info.FKeySchema = strings.ToLower(info.FKeySchema)
-		info.FKeyTable = strings.ToLower(info.FKeyTable)
+		info.FKeyTable = util.ToSnake(info.FKeyTable)
 		for i := range info.LocalCols {
 			info.LocalCols[i] = strings.ToLower(util.ToSnake(strings.TrimSpace(info.LocalCols[i])))
 		}

--- a/tests/mssql_dialect_test.go
+++ b/tests/mssql_dialect_test.go
@@ -1,0 +1,156 @@
+package tests_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/dosco/graphjin/core/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mssqlPascalFixture creates a small PascalCase multi-word schema
+// (OrderGroups 1—* OrderLines) used to exercise MSSQL identifier
+// normalization that the snake_case shared fixtures cannot. Group 1 has 5
+// lines, group 2 has 1 line. Returns a cleanup func.
+func mssqlPascalFixture(t *testing.T, db *sql.DB) func() {
+	t.Helper()
+	stmts := []string{
+		`IF OBJECT_ID('OrderLines','U') IS NOT NULL DROP TABLE OrderLines`,
+		`IF OBJECT_ID('OrderGroups','U') IS NOT NULL DROP TABLE OrderGroups`,
+		`CREATE TABLE OrderGroups (GroupKey INT PRIMARY KEY, GroupName NVARCHAR(100) NOT NULL)`,
+		`CREATE TABLE OrderLines (
+			LineKey INT PRIMARY KEY,
+			GroupKey INT NOT NULL,
+			LineLabel NVARCHAR(100) NOT NULL,
+			CONSTRAINT order_lines_group_fk FOREIGN KEY (GroupKey) REFERENCES OrderGroups(GroupKey)
+		)`,
+		`INSERT INTO OrderGroups (GroupKey, GroupName) VALUES (1, N'Group One'), (2, N'Group Two')`,
+		`INSERT INTO OrderLines (LineKey, GroupKey, LineLabel) VALUES
+			(1,1,N'L1'),(2,1,N'L2'),(3,1,N'L3'),(4,1,N'L4'),(5,1,N'L5'),(6,2,N'L6')`,
+	}
+	for _, s := range stmts {
+		_, err := db.Exec(s)
+		require.NoError(t, err, "fixture setup: %s", s)
+	}
+	return func() {
+		_, _ = db.Exec(`IF OBJECT_ID('OrderLines','U') IS NOT NULL DROP TABLE OrderLines`)
+		_, _ = db.Exec(`IF OBJECT_ID('OrderGroups','U') IS NOT NULL DROP TABLE OrderGroups`)
+	}
+}
+
+// TestMSSQLPascalCaseNaming verifies that multi-word PascalCase tables and
+// columns are reachable under their snake_case GraphQL names and that the FK
+// relationship resolves. Without consistent ToSnake table normalization,
+// OrderGroups registers as "ordergroups" and the snake_case root is not found.
+func TestMSSQLPascalCaseNaming(t *testing.T) {
+	if dbType != "mssql" {
+		t.Skipf("skipping MSSQL naming test for %s", dbType)
+	}
+	cleanup := mssqlPascalFixture(t, db)
+	defer cleanup()
+
+	conf := newConfig(&core.Config{DBType: dbType, DisableAllowList: true})
+	gj, err := core.NewGraphJin(conf, db)
+	require.NoError(t, err)
+	defer gj.Close()
+
+	ctx := context.Background()
+
+	t.Run("table_and_column_roots_resolve", func(t *testing.T) {
+		res, err := gj.GraphQL(ctx, `query {
+			g: order_groups(order_by: { group_key: asc }) { gk: group_key gn: group_name }
+			l: order_lines(limit: 3, order_by: { line_key: asc }) { lk: line_key }
+		}`, nil, nil)
+		require.NoError(t, err, "snake_case roots for PascalCase tables must resolve")
+
+		var out struct {
+			G []struct {
+				GK int    `json:"gk"`
+				GN string `json:"gn"`
+			} `json:"g"`
+			L []struct {
+				LK int `json:"lk"`
+			} `json:"l"`
+		}
+		require.NoError(t, json.Unmarshal(res.Data, &out))
+		require.Len(t, out.G, 2)
+		assert.Equal(t, "Group One", out.G[0].GN, "group_name -> GroupName round-trip")
+		assert.Len(t, out.L, 3, "order_lines root resolves and limit applies")
+	})
+
+	t.Run("fk_relationship_join", func(t *testing.T) {
+		res, err := gj.GraphQL(ctx, `query {
+			g: order_groups(where: { group_key: { eq: 1 } }) {
+				gk: group_key
+				lines: order_lines(order_by: { line_key: asc }) { lk: line_key }
+			}
+		}`, nil, nil)
+		require.NoError(t, err, "FK join order_groups -> order_lines must resolve")
+
+		var out struct {
+			G []struct {
+				GK    int `json:"gk"`
+				Lines []struct {
+					LK int `json:"lk"`
+				} `json:"lines"`
+			} `json:"g"`
+		}
+		require.NoError(t, json.Unmarshal(res.Data, &out))
+		require.Len(t, out.G, 1)
+		assert.Len(t, out.G[0].Lines, 5, "group 1 has 5 child lines (ground truth)")
+	})
+
+	// Guards #605: a child-relationship limit must cap nested rows.
+	t.Run("nested_child_limit", func(t *testing.T) {
+		res, err := gj.GraphQL(ctx, `query {
+			g: order_groups(where: { group_key: { eq: 1 } }) {
+				lines: order_lines(limit: 2, order_by: { line_key: asc }) { lk: line_key }
+			}
+		}`, nil, nil)
+		require.NoError(t, err)
+
+		var out struct {
+			G []struct {
+				Lines []struct {
+					LK int `json:"lk"`
+				} `json:"lines"`
+			} `json:"g"`
+		}
+		require.NoError(t, json.Unmarshal(res.Data, &out))
+		require.Len(t, out.G, 1)
+		assert.Len(t, out.G[0].Lines, 2, "nested limit:2 must cap the 5 child lines to 2")
+	})
+}
+
+// TestMSSQLVariableLimitUnderAnalytics guards #604: with analytics_mode on, a
+// variable limit (limit: $n) must still apply instead of returning all rows.
+func TestMSSQLVariableLimitUnderAnalytics(t *testing.T) {
+	if dbType != "mssql" {
+		t.Skipf("skipping MSSQL variable-limit test for %s", dbType)
+	}
+
+	conf := newConfig(&core.Config{DBType: dbType, DisableAllowList: true, AnalyticsMode: true})
+	gj, err := core.NewGraphJin(conf, db)
+	require.NoError(t, err)
+	defer gj.Close()
+
+	var total int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM products`).Scan(&total))
+	require.Greater(t, total, 3, "need more than 3 products for the limit to matter")
+
+	res, err := gj.GraphQL(context.Background(), `query ($l: Int) {
+		p: products(unrestricted: true, limit: $l, order_by: { id: asc }) { id }
+	}`, json.RawMessage(`{"l":3}`), nil)
+	require.NoError(t, err)
+
+	var out struct {
+		P []struct {
+			ID int `json:"id"`
+		} `json:"p"`
+	}
+	require.NoError(t, json.Unmarshal(res.Data, &out))
+	assert.Len(t, out.P, 3, "variable limit must apply under analytics_mode, not return all rows")
+}


### PR DESCRIPTION
## Summary

Fixes three MSSQL dialect bugs found testing against a PascalCase SQL Server schema, corrects stale dialect doc comments, and adds MSSQL regression tests to the integration suite.

### Fixes

- **Table-name normalization (#603)** — `core/internal/introspection/tables.go`: multi-word PascalCase table/FK-table names were `strings.ToLower`'d (`OrderRows` → `orderrows`) while columns use `util.ToSnake` (`order_rows`), so the snake_case GraphQL root was unreachable (`table not found`). Table/FK-table names now use `util.ToSnake` to match columns; `NameMap` still maps back to the real identifier in generated SQL. This mirrors the earlier `FKeyCol` fix (#543/#544).

- **Variable LIMIT under analytics_mode (#604)** — `core/internal/dialect/mssql.go`: the render gates only fired on a literal `Paging.Limit`, so a `limit: $n` (where the value lives in `LimitVar`, `Limit == 0` under `analytics_mode`) emitted no `OFFSET/FETCH` and returned all rows. Gates now also fire on `Paging.LimitVar`.

- **Nested/child LIMIT ignored (#605)** — `core/internal/dialect/mssql.go`: the plural branch of `RenderInlineChild` rendered `ORDER BY` but never called `RenderLimit`, so a child relationship limit (`parent { child(limit: N) }`) returned all child rows. It now renders `OFFSET/FETCH` for child selects.

### Docs

- Corrected the stale `mssql.go` "Known Limitations" block: cursor pagination and nested mutations both work now; removed the variable-LIMIT note (fixed here). Documented that the OPENJSON paths (variable inserts, variable `IN` filters, JSON arrays) require database `COMPATIBILITY_LEVEL >= 130`.

### Tests

- `tests/mssql_dialect_test.go` (container suite, MSSQL-gated): a PascalCase `OrderGroups` 1—* `OrderLines` fixture validates table/column/FK-table snake_case resolution and nested-limit capping; a separate test validates variable LIMIT under `analytics_mode`.

## Test plan

- [x] `go test -db=mssql -tags mssql` (MSSQL container) — new + existing suite
- [x] `go test ./internal/psql/ ./internal/qcode/ ./internal/introspection/ ./internal/sdata/ ./internal/util/` (unit) — no cross-dialect regression
- [x] CI: oracle/snowflake/postgres/mysql container suites (shared introspection path; `ToSnake == ToLower` for their non-PascalCase identifiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
