### PR TITLE
fix(openapi): sanitize generated GraphQL field names

### DIFF
--- a/core/openapi/classifier.go
+++ b/core/openapi/classifier.go
@@ -399,7 +399,46 @@ func exposeAs(specKey, operationID string, override OperationOverride) string {
 	if override.ExposeAs != "" {
 		return override.ExposeAs
 	}
-	return specKey + "_" + toSnakeCase(operationID)
+	return sanitizeGraphQLName(specKey + "_" + toSnakeCase(operationID))
+}
+
+// sanitizeGraphQLName converts an arbitrary generated name to the GraphQL
+// Name grammar: [_A-Za-z][_0-9A-Za-z]*. OpenAPI operationIds are free-form
+// strings, so punctuation that is valid there must not leak into the field
+// names exposed by GraphJin. Consecutive invalid characters collapse to keep
+// generated names readable; existing valid underscores remain unchanged.
+func sanitizeGraphQLName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 1)
+	replacingInvalid := false
+
+	for _, r := range s {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		if !isLetter && !isDigit && r != '_' {
+			if replacingInvalid {
+				continue
+			}
+			r = '_'
+			replacingInvalid = true
+		} else {
+			replacingInvalid = false
+		}
+
+		if b.Len() == 0 && isDigit {
+			b.WriteByte('_')
+		}
+		b.WriteRune(r)
+	}
+
+	if b.Len() == 0 {
+		return "_"
+	}
+	name := b.String()
+	if strings.HasPrefix(name, "__") {
+		name = "_" + strings.TrimLeft(name, "_")
+	}
+	return name
 }
 
 // toSnakeCase converts camelCase / PascalCase identifiers to snake_case.

--- a/core/openapi/classifier_test.go
+++ b/core/openapi/classifier_test.go
@@ -70,6 +70,37 @@ paths:
 	}
 }
 
+func TestClassifySanitizesGeneratedExposeAs(t *testing.T) {
+	doc := loadDoc(t, `
+openapi: 3.0.0
+info: { title: Test, version: 1.0.0 }
+paths:
+  /widgets:
+    get:
+      operationId: WidgetController_list_v1.0
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: string }
+`)
+
+	spec := &Spec{Key: "partner-api.v2"}
+	ops, _ := classifyAll(spec, doc, SpecConfig{})
+	if len(ops) != 1 {
+		t.Fatalf("want 1 op, got %d", len(ops))
+	}
+	if got, want := ops[0].ExposeAs, "partner_api_v2_widget_controller_list_v1_0"; got != want {
+		t.Errorf("exposeAs = %q, want %q", got, want)
+	}
+}
+
 func TestClassifyRowJoinUpgrade(t *testing.T) {
 	doc := loadDoc(t, `
 openapi: 3.0.0
@@ -294,6 +325,27 @@ func TestToSnakeCase(t *testing.T) {
 		got := toSnakeCase(tc.in)
 		if got != tc.want {
 			t.Errorf("toSnakeCase(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSanitizeGraphQLName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"valid_name", "valid_name"},
+		{"valid__name", "valid__name"},
+		{"api-v2.WidgetController_list_v1.0", "api_v2_WidgetController_list_v1_0"},
+		{"3pl_list_widgets", "_3pl_list_widgets"},
+		{"__reserved", "_reserved"},
+		{"many...separators", "many_separators"},
+		{"ümlaut", "_mlaut"},
+		{"", "_"},
+	}
+	for _, tc := range cases {
+		got := sanitizeGraphQLName(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeGraphQLName(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- sanitize default OpenAPI field names to the GraphQL `Name` grammar
- replace punctuation and non-ASCII characters with readable underscore separators
- prefix names that would begin with a digit and avoid the reserved `__` prefix
- preserve existing valid names and explicit `expose_as` overrides

## Why

OpenAPI permits punctuation in `operationId` values. GraphJin previously passed that punctuation through when constructing the default field name, so an ID such as `WidgetController_list_v1.0` generated a field containing `.0` that the GraphQL parser could not select.

## Tests

- regression coverage for dotted operation IDs and punctuated spec keys
- table coverage for valid names, repeated underscores, leading digits, reserved prefixes, repeated punctuation, Unicode, and empty input
- `go test ./openapi -count=1`
- `go test ./... -count=1` from the `core` module

Fixes #616
