### PR TITLE
fix(openapi): sanitize punctuation in operationId for valid GraphQL field names

### DIFF
--- a/core/openapi/classifier.go
+++ b/core/openapi/classifier.go
@@ -402,11 +402,10 @@ func exposeAs(specKey, operationID string, override OperationOverride) string {
 	return specKey + "_" + toSnakeCase(operationID)
 }
 
-// toSnakeCase converts camelCase / PascalCase identifiers to snake_case.
-// It's intentionally conservative: only inserts an underscore at a
-// lower→upper transition. Acronyms (UserID → user_id) are handled by
-// also breaking before the last upper in an upper run that's followed
-// by a lower — the standard idiom for this conversion.
+// toSnakeCase converts camelCase / PascalCase identifiers and arbitrary
+// operationId strings to valid snake_case identifiers suitable for GraphQL
+// field names. Non-alphanumeric characters (such as '.', '-', '/') are
+// converted to underscores, and consecutive underscores are collapsed.
 func toSnakeCase(s string) string {
 	if s == "" {
 		return s
@@ -414,22 +413,34 @@ func toSnakeCase(s string) string {
 	var b strings.Builder
 	b.Grow(len(s) + 4)
 	runes := []rune(s)
+	lastWasUnderscore := false
+
 	for i, r := range runes {
 		isUpper := r >= 'A' && r <= 'Z'
-		if i > 0 && isUpper {
-			prev := runes[i-1]
-			prevIsLower := prev >= 'a' && prev <= 'z'
-			nextIsLower := i+1 < len(runes) && runes[i+1] >= 'a' && runes[i+1] <= 'z'
-			prevIsUpper := prev >= 'A' && prev <= 'Z'
-			if prevIsLower || (prevIsUpper && nextIsLower) {
+		isLower := r >= 'a' && r <= 'z'
+		isDigit := r >= '0' && r <= '9'
+
+		if isUpper {
+			if i > 0 && !lastWasUnderscore {
+				prev := runes[i-1]
+				prevIsLower := (prev >= 'a' && prev <= 'z') || (prev >= '0' && prev <= '9')
+				nextIsLower := i+1 < len(runes) && runes[i+1] >= 'a' && runes[i+1] <= 'z'
+				prevIsUpper := prev >= 'A' && prev <= 'Z'
+				if prevIsLower || (prevIsUpper && nextIsLower) {
+					b.WriteByte('_')
+				}
+			}
+			b.WriteRune(r + ('a' - 'A'))
+			lastWasUnderscore = false
+		} else if isLower || isDigit {
+			b.WriteRune(r)
+			lastWasUnderscore = false
+		} else {
+			if !lastWasUnderscore && b.Len() > 0 {
 				b.WriteByte('_')
+				lastWasUnderscore = true
 			}
 		}
-		if isUpper {
-			b.WriteRune(r + ('a' - 'A'))
-		} else {
-			b.WriteRune(r)
-		}
 	}
-	return b.String()
+	return strings.Trim(b.String(), "_")
 }

--- a/core/openapi/classifier_test.go
+++ b/core/openapi/classifier_test.go
@@ -288,6 +288,18 @@ func TestToSnakeCase(t *testing.T) {
 		{"listAuditLogs", "list_audit_logs"},
 		{"GetHTTPStatus", "get_http_status"},
 		{"already_snake", "already_snake"},
+		{"WidgetController_list_v1.0", "widget_controller_list_v1_0"},
+		{"user.profile-v2", "user_profile_v2"},
+		{"api.v1.0.users.list", "api_v1_0_users_list"},
+		{"some--operation...id", "some_operation_id"},
+		{"trailing.dots...", "trailing_dots"},
+		{"XMLHttpRequest", "xml_http_request"},
+		{"foo...bar", "foo_bar"},
+		{".list", "list"},
+		{"v1.2.3", "v1_2_3"},
+		{"2FA_verify", "2_fa_verify"},
+		{"---", ""},
+		{"Widget_Controller", "widget_controller"},
 		{"", ""},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Description

Fixes #616.

When an OpenAPI specification defines an `operationId` containing punctuation (such as `WidgetController_list_v1.0` or `user.profile-v2`), GraphJin generates a default GraphQL root field name via `exposeAs` using `toSnakeCase(operationId)`. Previously, non-alphanumeric characters like `.` or `-` were passed through unchanged, resulting in invalid GraphQL field names that violate the GraphQL identifier grammar `[_A-Za-z][_0-9A-Za-z]*` and cause GraphQL query parsing to fail.

### Changes
1. In `core/openapi/classifier.go` (`toSnakeCase`):
   - Normalizes non-alphanumeric characters (such as `.`, `-`, `/`) to underscores.
   - Collapses consecutive underscores.
   - Trims leading and trailing underscores.
   - Preserves camelCase/PascalCase boundaries, acronym runs (e.g. `XMLHttpRequest` -> `xml_http_request`), and numbers (e.g. `v1.2.3` -> `v1_2_3`).
2. In `core/openapi/classifier_test.go`:
   - Added test cases covering `WidgetController_list_v1.0`, `user.profile-v2`, `api.v1.0.users.list`, `some--operation...id`, `trailing.dots...`, `XMLHttpRequest`, `foo...bar`, `.list`, `v1.2.3`, `2FA_verify`, `---`, and `Widget_Controller`.

## Testing
- `go test ./core/openapi/... -v` passes cleanly (all unit tests green).
