### PR TITLE
docs: expand JWT authentication guide

### DIFF
--- a/website/content/configure/auth-rbac.md
+++ b/website/content/configure/auth-rbac.md
@@ -8,17 +8,86 @@ weight: 30
 
 ## Auth providers
 
-GraphJin supports JWT/OIDC-style config, JWKS refresh, static public keys, and header authentication.
+GraphJin accepts JWTs minted by your application or identity provider and verifies them before a
+request reaches the compiler. It supports rotating JWKS endpoints, shared HMAC secrets, static public
+keys, and Bearer-token authentication. This section covers request verification after a token has been
+issued; login redirects and session creation are separate from the verifier.
+
+{{< svg "auth-modes" "GraphJin authentication and authorization modes" >}}
+
+### Choose a JWT verification mode
+
+| Use case | `auth.jwt.provider` | Verification material |
+| --- | --- | --- |
+| OIDC provider with rotating keys | `jwks` | `jwks_url` |
+| Application-issued HMAC token | `other` | `secret` |
+| Application-issued RSA/ECDSA token | `other` | `public_key` and `public_key_type` |
+| Firebase ID token | `firebase` | `audience` (your Firebase project ID) |
+
+For an external OIDC provider, configure the JWKS endpoint and pin the expected audience and issuer:
 
 ```yaml
+auth_fail_block: true
+
 auth:
   type: jwt
   jwt:
+    provider: jwks
     jwks_url: https://issuer.example.com/.well-known/jwks.json
-    audience: graphjin
+    audience: graphjin-api
+    issuer: https://issuer.example.com/
 ```
 
-{{< svg "auth-modes" "GraphJin authentication and authorization modes" >}}
+`provider: jwks` is required for a JWKS endpoint. Without it, GraphJin selects the generic key
+provider, which expects `secret` or `public_key` instead. Set `audience` and `issuer` to the exact
+values emitted by your identity provider; GraphJin checks each claim whose expected value is
+configured. GraphJin fetches the JWKS when token verification first needs a key; startup only checks
+that `jwks_url` is set.
+
+For an application-issued HMAC token, keep the shared secret outside the config file:
+
+```yaml
+auth_fail_block: true
+
+auth:
+  type: jwt
+  jwt:
+    provider: other
+    secret: "" # supplied by GJ_AUTH_JWT_SECRET
+    audience: graphjin-api
+    issuer: https://app.example.com/
+```
+
+Set the shared key in the process environment as `GJ_AUTH_JWT_SECRET`; it maps directly to
+the empty `auth.jwt.secret` field without putting the key in the config file.
+
+The full field list and static-public-key example are in the
+[configuration reference](https://github.com/dosco/graphjin/blob/master/CONFIG.md#authentication-configuration).
+
+### Send an authenticated request
+
+Every accepted JWT must contain a string `sub` claim. If `audience` or `issuer` is configured, the
+token must also contain the matching `aud` or `iss` claim.
+
+The examples enable `auth_fail_block`. With an explicit `anon` role, a missing or invalid token returns
+HTTP 401 before the request reaches the compiler. When no `anon` role exists and `default_block`
+remains enabled, GraphJin delegates rejection to the compiler's default-block policy instead.
+
+Send the token as a Bearer credential:
+
+```bash
+curl http://localhost:8080/api/v1/graphql \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  --data '{"query":"query { users { id name } }"}'
+```
+
+{{< verified by="TestJWTTokenInAuthorizationHeader" file="auth/auth_test.go" line="13" >}}
+
+Browser applications can instead set `auth.cookie` to the name of the cookie that contains the JWT.
+GraphJin checks that cookie first, then falls back to the `Authorization` header when the cookie is
+absent or empty. Cookie attributes such as `HttpOnly`, `Secure`, and `SameSite` are set by the
+application or identity flow that issues the cookie, not by the JWT verifier.
 
 ## Identity mapping in source mode
 
@@ -46,6 +115,8 @@ sources:
 ```
 
 {{< verified by="TestApplySourceAccessRulesGeneratesAccountFiltersAndClassifications" file="core/source_access_test.go" line="14" >}}
+
+{{< verified by="TestSourceModeHTTPJWTIdentityAndSystemRoots" file="serv/source_mode_http_test.go" line="27" >}}
 
 ## Role query
 


### PR DESCRIPTION
## Summary

- explain how to choose between JWKS, HMAC, static-key, and Firebase JWT verification
- fix the JWKS example by selecting `provider: jwks` and pinning audience and issuer
- keep the HMAC secret in `GJ_AUTH_JWT_SECRET` and document fail-closed/default-block behavior
- document required claims, Bearer/cookie token transport, and test-backed source-mode identity mapping

## Why

The current Auth And RBAC page configures `jwks_url` without selecting the JWKS provider. That falls through to the generic key provider, which expects `secret` or `public_key` and fails with `undefined key`.

This also gives readers the missing request-level flow requested in #397: who issues the token, which claims GraphJin verifies, and how the client sends it.

Addresses #397.

## Verification

- temporary Go contract probes (not committed):
  - existing JWKS example fails initialization with `undefined key`
  - corrected `provider: jwks` example initializes successfully
  - configured JWT cookie takes precedence and Bearer fallback works when the cookie is absent
  - `GJ_AUTH_JWT_SECRET` overrides the empty `auth.jwt.secret` field and `auth_fail_block` decodes true
- `go test ./auth -run 'TestJWTTokenInAuthorizationHeader$' -count=1 -v`
- `go test ./core -run 'TestApplySourceAccessRulesGeneratesAccountFiltersAndClassifications$' -count=1 -v`
- `go test ./serv -run 'TestSourceModeHTTPJWTIdentityAndSystemRoots$' -count=1 -v`
- `npm ci` in `website/`
- `npm run build` in `website/`
- `npm run check` in `website/`
