### PR TITLE
fix(core): enforce OpenAPI query and timeout semantics

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1994,6 +1994,49 @@ sources:
 
 Without these caps, a 1000-row parent select would spawn 1000 parallel requests upstream — a reliable way to get rate-limited.
 
+### Per-Spec Timeout
+
+Every OpenAPI call has an end-to-end timeout. The default is `8s`; override it
+per spec when the upstream needs a smaller or larger budget:
+
+```yaml
+sources:
+  - name: upstream
+    kind: api
+    specs:
+      interaction_studio:
+        timeout: 5s
+```
+
+The timeout covers authentication, retries, and reading the response body. If
+an upstream times out, GraphJin returns that field as `null`, includes a
+GraphQL error, and preserves successful sibling roots in `data`.
+
+### Filtering, Ordering, and Paging API Results
+
+OpenAPI list roots and row-join objects support GraphJin's common query
+arguments. Declared OpenAPI path/query parameters are still sent upstream;
+`where`, `order_by`, `limit`, and `offset` are enforced on the returned JSON:
+
+```graphql
+query {
+  alerts(
+    where: { severity: { eq: "critical" } }
+    order_by: { warningCount: desc }
+    limit: 10
+  ) {
+    id
+    severity
+    warningCount
+  }
+}
+```
+
+Filtering requires object-shaped rows declared by the operation's JSON
+response schema. Unsupported operators fail with an explicit GraphQL error;
+they are never silently ignored. Cursor pagination and `distinct` are not
+supported for API responses; use `limit` and `offset` for paging.
+
 ### Operation Overrides
 
 Tweak per-operation presentation:

--- a/core/openapi/caller.go
+++ b/core/openapi/caller.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // Caller executes a single OpenAPI operation. One Caller is constructed
@@ -27,6 +28,7 @@ type Caller struct {
 	limiter *limiter
 	http    *http.Client
 	baseURL string
+	timeout time.Duration
 }
 
 // CallParams carries the per-call inputs. PathValues populates the URL
@@ -65,12 +67,17 @@ func NewCaller(op *OpDescriptor, baseURL string, auth AuthProvider, lim *limiter
 	if op != nil && op.Mode == OpModeMutation {
 		httpClient = clientWithoutRedirects(httpClient)
 	}
+	timeout := httpClient.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
 	return &Caller{
 		op:      op,
 		auth:    auth,
 		limiter: lim,
 		http:    httpClient,
 		baseURL: strings.TrimRight(baseURL, "/"),
+		timeout: timeout,
 	}
 }
 
@@ -94,6 +101,8 @@ func clientWithoutRedirects(client *http.Client) *http.Client {
 // after invalidating the auth provider's cached token — this handles
 // the common case of a service-credential token expiring mid-flight.
 func (c *Caller) Call(ctx context.Context, p CallParams) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
 	result, err := c.call(ctx, p, false)
 	if err != nil {
 		return nil, err
@@ -113,6 +122,8 @@ func (c *Caller) CallMutation(ctx context.Context, p CallParams) (CallResult, er
 	if c == nil || c.op == nil || c.op.Mode != OpModeMutation {
 		return CallResult{}, fmt.Errorf("openapi: caller is not an exposed mutation")
 	}
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
 	return c.call(ctx, p, true)
 }
 
@@ -232,6 +243,12 @@ type upstreamTransportError struct {
 }
 
 func (e *upstreamTransportError) Error() string {
+	if errors.Is(e.err, context.DeadlineExceeded) {
+		return fmt.Sprintf("openapi: %s %s timed out", e.method, e.operationID)
+	}
+	if errors.Is(e.err, context.Canceled) {
+		return fmt.Sprintf("openapi: %s %s canceled", e.method, e.operationID)
+	}
 	return fmt.Sprintf("openapi: %s %s transport error", e.method, e.operationID)
 }
 

--- a/core/openapi/config.go
+++ b/core/openapi/config.go
@@ -5,6 +5,14 @@
 // remote_api resolver.
 package openapi
 
+import "time"
+
+// DefaultTimeout bounds one upstream operation (including authentication)
+// when a spec does not set an explicit timeout. It stays below GraphJin's
+// standalone HTTP write deadline so an upstream stall can still be returned
+// as a GraphQL error instead of expiring the response socket first.
+const DefaultTimeout = 8 * time.Second
+
 // SpecConfig is the per-spec section a user adds to the GraphJin config
 // (keyed by spec filename without extension). Everything that cannot be
 // derived from the OpenAPI document itself lives here: credentials, base
@@ -42,6 +50,12 @@ type SpecConfig struct {
 	// Without this, a 1000-row parent select would spawn 1000 parallel
 	// HTTP calls to the upstream — a reliable way to get rate-limited.
 	Concurrency ConcurrencyConfig `mapstructure:"concurrency" json:"concurrency" yaml:"concurrency"`
+
+	// Timeout bounds each upstream request, including token acquisition. Zero
+	// selects DefaultTimeout. Keeping the bound per spec lets slower services
+	// opt into a larger budget when GraphJin is embedded behind a compatible
+	// outer HTTP deadline.
+	Timeout time.Duration `mapstructure:"timeout" json:"timeout" yaml:"timeout" jsonschema:"title=Upstream Request Timeout"`
 
 	// MaxRequestBytes and MaxResponseBytes bound encoded request bodies and
 	// upstream responses. Zero selects conservative package defaults.

--- a/core/openapi/integration_test.go
+++ b/core/openapi/integration_test.go
@@ -6,8 +6,63 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
+
+func TestSpecRuntimeAppliesPerSpecTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   time.Duration
+		expects time.Duration
+	}{
+		{name: "default", expects: DefaultTimeout},
+		{name: "configured", value: 125 * time.Millisecond, expects: 125 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &Spec{Key: "timeout", Timeout: tt.value, Operations: []OpDescriptor{{
+				OperationID: "list", Method: http.MethodGet, PathTemplate: "/items", Mode: OpModeList,
+			}}}
+			runtime, err := NewSpecRuntime(spec, &http.Client{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			caller, ok := runtime.Caller("list")
+			if !ok {
+				t.Fatal("caller not registered")
+			}
+			if caller.http.Timeout != tt.expects {
+				t.Fatalf("HTTP timeout = %s, want %s", caller.http.Timeout, tt.expects)
+			}
+		})
+	}
+
+	t.Run("preserves stricter host timeout", func(t *testing.T) {
+		spec := &Spec{Key: "timeout", Timeout: time.Second, Operations: []OpDescriptor{{
+			OperationID: "list", Method: http.MethodGet, PathTemplate: "/items", Mode: OpModeList,
+		}}}
+		runtime, err := NewSpecRuntime(spec, &http.Client{Timeout: 50 * time.Millisecond})
+		if err != nil {
+			t.Fatal(err)
+		}
+		caller, ok := runtime.Caller("list")
+		if !ok {
+			t.Fatal("caller not registered")
+		}
+		if caller.http.Timeout != 50*time.Millisecond {
+			t.Fatalf("HTTP timeout = %s, want stricter host timeout 50ms", caller.http.Timeout)
+		}
+	})
+}
+
+func TestSpecRuntimeRejectsNegativeTimeout(t *testing.T) {
+	_, err := NewSpecRuntime(&Spec{Key: "invalid", Timeout: -time.Second}, &http.Client{})
+	if err == nil || !strings.Contains(err.Error(), "timeout must not be negative") {
+		t.Fatalf("negative timeout error = %v", err)
+	}
+}
 
 // TestEndToEndLoadAndCall exercises the full pipeline: spec on disk →
 // loader → runtime → caller hitting an httptest server. This is the

--- a/core/openapi/loader.go
+++ b/core/openapi/loader.go
@@ -112,6 +112,7 @@ func Load(opts LoaderOptions, configs map[string]SpecConfig, logger *log.Logger)
 			BaseURL:          baseURL,
 			Auth:             cfg.Auth,
 			Concurrency:      cfg.Concurrency,
+			Timeout:          cfg.Timeout,
 			MaxRequestBytes:  cfg.MaxRequestBytes,
 			MaxResponseBytes: cfg.MaxResponseBytes,
 		}

--- a/core/openapi/registry.go
+++ b/core/openapi/registry.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -179,6 +180,7 @@ type Spec struct {
 	BaseURL          string
 	Auth             AuthConfig
 	Concurrency      ConcurrencyConfig
+	Timeout          time.Duration
 	MaxRequestBytes  int64
 	MaxResponseBytes int64
 	Operations       []OpDescriptor

--- a/core/openapi/runtime.go
+++ b/core/openapi/runtime.go
@@ -30,6 +30,19 @@ func NewSpecRuntime(spec *Spec, httpClient *http.Client) (*SpecRuntime, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
+	if spec.Timeout < 0 {
+		return nil, fmt.Errorf("openapi: %s timeout must not be negative", spec.Key)
+	}
+	timeout := spec.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+	if httpClient.Timeout > 0 && httpClient.Timeout < timeout {
+		timeout = httpClient.Timeout
+	}
+	client := *httpClient
+	client.Timeout = timeout
+	httpClient = &client
 
 	auth, err := NewAuthProvider(spec.Auth, httpClient)
 	if err != nil {

--- a/core/openapi_bridge.go
+++ b/core/openapi_bridge.go
@@ -32,13 +32,21 @@ func (b *openapiBridge) Resolve(ctx context.Context, req ResolverReq) ([]byte, e
 		}
 	}
 	if b.topLevel {
-		return b.callTopLevel(ctx, req.Sel)
+		body, err := b.callTopLevel(ctx, req.Sel)
+		if err != nil {
+			return nil, err
+		}
+		return applyOpenAPIQuery(body, req)
 	}
 	params := openapi.CallParams{}
 	if b.pathName != "" {
 		params.PathValues = map[string]string{b.pathName: req.ID}
 	}
-	return b.caller.Call(ctx, params)
+	body, err := b.caller.Call(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return applyOpenAPIQuery(body, req)
 }
 
 func (b *openapiBridge) callTopLevel(ctx context.Context, sel *qcode.Select) ([]byte, error) {
@@ -324,6 +332,7 @@ func openAPISpecFingerprint(sp *openapi.Spec) string {
 		h.Write([]byte{0})
 		writeFingerprintJSON(h, sp.Auth)
 		writeFingerprintJSON(h, sp.Concurrency)
+		writeFingerprintJSON(h, sp.Timeout)
 		writeFingerprintJSON(h, openAPIOperationFingerprintParts(sp.Operations))
 		if sp.SourcePath != "" {
 			if b, err := os.ReadFile(sp.SourcePath); err == nil {

--- a/core/openapi_bridge_test.go
+++ b/core/openapi_bridge_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dosco/graphjin/core/v3/internal/sdata"
 	"github.com/dosco/graphjin/core/v3/openapi"
@@ -80,6 +81,14 @@ func TestSynthesiseResolvers(t *testing.T) {
 		if tl.Props["spec_key"] != "is" {
 			t.Errorf("top-level missing spec_key: %+v", tl.Props)
 		}
+	}
+}
+
+func TestOpenAPISpecFingerprintIncludesTimeout(t *testing.T) {
+	first := &openapi.Spec{Key: "api", Timeout: time.Second}
+	second := &openapi.Spec{Key: "api", Timeout: 2 * time.Second}
+	if openAPISpecFingerprint(first) == openAPISpecFingerprint(second) {
+		t.Fatal("per-spec timeout must participate in resolver cache fingerprinting")
 	}
 }
 

--- a/core/openapi_query.go
+++ b/core/openapi_query.go
@@ -1,0 +1,700 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/dosco/graphjin/core/v3/internal/qcode"
+)
+
+// applyOpenAPIQuery applies GraphJin's common query arguments to a resolved
+// OpenAPI payload. OpenAPI parameters are pushed upstream separately through
+// Select.ExtraArgs; where/order_by/limit/offset are GraphJin arguments and must
+// be enforced after the call because an arbitrary REST contract has no generic
+// representation for them.
+func applyOpenAPIQuery(body []byte, req ResolverReq) ([]byte, error) {
+	sel := req.Sel
+	if sel == nil || !openAPISelectNeedsProcessing(sel) {
+		return body, nil
+	}
+	if len(sel.DistinctOn) != 0 {
+		return nil, fmt.Errorf("openapi: distinct is not supported on API response fields")
+	}
+	if sel.Paging.Cursor || sel.Paging.CursorVar != "" || sel.Paging.Backward {
+		return nil, fmt.Errorf("openapi: cursor pagination is not supported on API response fields; use limit and offset")
+	}
+	if err := validateOpenAPIWhere(sel.Where.Exp); err != nil {
+		return nil, err
+	}
+	if err := validateOpenAPIOrderBy(sel.OrderBy); err != nil {
+		return nil, err
+	}
+
+	payload, err := decodeOpenAPIJSON(body)
+	if err != nil {
+		return nil, fmt.Errorf("openapi: decode query response: %w", err)
+	}
+
+	switch value := payload.(type) {
+	case []any:
+		rows := make([]map[string]any, 0, len(value))
+		for i, item := range value {
+			row, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("openapi: query response row %d must be a JSON object", i)
+			}
+			match, err := openAPIJSONMatches(row, sel.Where.Exp, req.Vars)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				rows = append(rows, row)
+			}
+		}
+		if err := sortOpenAPIRows(rows, sel.OrderBy); err != nil {
+			return nil, err
+		}
+		offset, limit, err := openAPIPage(sel, req.Vars)
+		if err != nil {
+			return nil, err
+		}
+		rows = pageOpenAPIRows(rows, offset, limit)
+		return json.Marshal(rows)
+
+	case map[string]any:
+		match, err := openAPIJSONMatches(value, sel.Where.Exp, req.Vars)
+		if err != nil {
+			return nil, err
+		}
+		offset, _, err := openAPIPage(sel, req.Vars)
+		if err != nil {
+			return nil, err
+		}
+		if !match || offset > 0 {
+			return []byte("null"), nil
+		}
+		return json.Marshal(value)
+
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf("openapi: query response must be a JSON object or array, got %T", payload)
+	}
+}
+
+func openAPISelectNeedsProcessing(sel *qcode.Select) bool {
+	if sel == nil {
+		return false
+	}
+	return sel.Where.Exp != nil || len(sel.OrderBy) != 0 ||
+		len(sel.DistinctOn) != 0 || sel.Paging.Cursor ||
+		sel.Paging.CursorVar != "" || sel.Paging.Backward ||
+		sel.Paging.Limit != 0 || sel.Paging.LimitVar != "" ||
+		sel.Paging.Offset != 0 || sel.Paging.OffsetVar != ""
+}
+
+func decodeOpenAPIJSON(body []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("multiple JSON values")
+		}
+		return nil, err
+	}
+	return value, nil
+}
+
+func openAPIJSONMatches(row map[string]any, ex *qcode.Exp, vars map[string]json.RawMessage) (bool, error) {
+	if ex == nil {
+		return true, nil
+	}
+	switch ex.Op {
+	case qcode.OpNop:
+		return true, nil
+	case qcode.OpAnd:
+		for _, child := range ex.Children {
+			ok, err := openAPIJSONMatches(row, child, vars)
+			if err != nil || !ok {
+				return ok, err
+			}
+		}
+		return true, nil
+	case qcode.OpOr:
+		for _, child := range ex.Children {
+			ok, err := openAPIJSONMatches(row, child, vars)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
+			}
+		}
+		return false, nil
+	case qcode.OpNot:
+		if len(ex.Children) == 0 {
+			return false, nil
+		}
+		ok, err := openAPIJSONMatches(row, ex.Children[0], vars)
+		return !ok, err
+	case qcode.OpFalse:
+		return false, nil
+	}
+
+	left, exists := openAPIObjectValue(row, openAPIExpColumnName(ex))
+	switch ex.Op {
+	case qcode.OpIsNull:
+		want, err := openAPIExpOptionalBool(ex, vars, true)
+		return (!exists || left == nil) == want, err
+	case qcode.OpIsNotNull:
+		return exists && left != nil, nil
+	case qcode.OpEqualsTrue:
+		return exists && left == true, nil
+	case qcode.OpNotEqualsTrue:
+		return !exists || left != true, nil
+	}
+	if !exists || left == nil {
+		return false, nil
+	}
+
+	if ex.Op == qcode.OpIn || ex.Op == qcode.OpNotIn {
+		values, err := openAPIExpList(ex, vars)
+		if err != nil {
+			return false, err
+		}
+		found := false
+		for _, value := range values {
+			if openAPIEqual(left, value) {
+				found = true
+				break
+			}
+		}
+		if ex.Op == qcode.OpNotIn {
+			found = !found
+		}
+		return found, nil
+	}
+
+	right, err := openAPIExpScalar(ex, vars)
+	if err != nil {
+		return false, err
+	}
+	switch ex.Op {
+	case qcode.OpEquals, qcode.OpNotDistinct:
+		return openAPIEqual(left, right), nil
+	case qcode.OpNotEquals, qcode.OpDistinct:
+		return !openAPIEqual(left, right), nil
+	case qcode.OpGreaterThan, qcode.OpGreaterOrEquals, qcode.OpLesserThan, qcode.OpLesserOrEquals:
+		cmp, err := compareOpenAPIValues(left, right)
+		if err != nil {
+			return false, fmt.Errorf("openapi where column %q: %w", openAPIExpColumnName(ex), err)
+		}
+		switch ex.Op {
+		case qcode.OpGreaterThan:
+			return cmp > 0, nil
+		case qcode.OpGreaterOrEquals:
+			return cmp >= 0, nil
+		case qcode.OpLesserThan:
+			return cmp < 0, nil
+		default:
+			return cmp <= 0, nil
+		}
+	case qcode.OpLike, qcode.OpNotLike, qcode.OpILike, qcode.OpNotILike:
+		insensitive := ex.Op == qcode.OpILike || ex.Op == qcode.OpNotILike
+		ok, err := openAPILike(fmt.Sprint(left), fmt.Sprint(right), insensitive)
+		if ex.Op == qcode.OpNotLike || ex.Op == qcode.OpNotILike {
+			ok = !ok
+		}
+		return ok, err
+	case qcode.OpRegex, qcode.OpNotRegex, qcode.OpIRegex, qcode.OpNotIRegex:
+		pattern := fmt.Sprint(right)
+		if ex.Op == qcode.OpIRegex || ex.Op == qcode.OpNotIRegex {
+			pattern = "(?i)" + pattern
+		}
+		ok, err := regexp.MatchString(pattern, fmt.Sprint(left))
+		if ex.Op == qcode.OpNotRegex || ex.Op == qcode.OpNotIRegex {
+			ok = !ok
+		}
+		return ok, err
+	case qcode.OpContains:
+		return openAPIContains(left, right), nil
+	case qcode.OpContainedIn:
+		return openAPIContains(right, left), nil
+	case qcode.OpHasInCommon:
+		return openAPIHasInCommon(left, right), nil
+	case qcode.OpHasKey:
+		return openAPIHasKey(left, fmt.Sprint(right)), nil
+	case qcode.OpHasKeyAny, qcode.OpHasKeyAll:
+		keys, ok := right.([]any)
+		if !ok {
+			return false, fmt.Errorf("openapi where operator %s expects a list", ex.Op)
+		}
+		matched := ex.Op == qcode.OpHasKeyAll
+		for _, key := range keys {
+			has := openAPIHasKey(left, fmt.Sprint(key))
+			if ex.Op == qcode.OpHasKeyAny && has {
+				return true, nil
+			}
+			if ex.Op == qcode.OpHasKeyAll && !has {
+				return false, nil
+			}
+		}
+		return matched, nil
+	default:
+		return false, fmt.Errorf("openapi where does not support operator %s", ex.Op)
+	}
+}
+
+func validateOpenAPIWhere(ex *qcode.Exp) error {
+	if ex == nil {
+		return nil
+	}
+	switch ex.Op {
+	case qcode.OpNop, qcode.OpFalse:
+		return nil
+	case qcode.OpAnd, qcode.OpOr, qcode.OpNot:
+		for _, child := range ex.Children {
+			if err := validateOpenAPIWhere(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	case qcode.OpEquals, qcode.OpNotEquals,
+		qcode.OpGreaterOrEquals, qcode.OpLesserOrEquals,
+		qcode.OpGreaterThan, qcode.OpLesserThan,
+		qcode.OpIn, qcode.OpNotIn,
+		qcode.OpLike, qcode.OpNotLike, qcode.OpILike, qcode.OpNotILike,
+		qcode.OpRegex, qcode.OpNotRegex, qcode.OpIRegex, qcode.OpNotIRegex,
+		qcode.OpContains, qcode.OpContainedIn, qcode.OpHasInCommon,
+		qcode.OpHasKey, qcode.OpHasKeyAny, qcode.OpHasKeyAll,
+		qcode.OpIsNull, qcode.OpIsNotNull,
+		qcode.OpNotDistinct, qcode.OpDistinct,
+		qcode.OpEqualsTrue, qcode.OpNotEqualsTrue:
+		if openAPIExpColumnName(ex) == "" {
+			return fmt.Errorf("openapi where supports response columns only")
+		}
+		if ex.Right.Table != "" || ex.Right.Col.Name != "" || ex.Right.ColName != "" {
+			return fmt.Errorf("openapi where does not support column-reference operands")
+		}
+		return nil
+	default:
+		return fmt.Errorf("openapi where does not support operator %s", ex.Op)
+	}
+}
+
+func openAPIExpColumnName(ex *qcode.Exp) string {
+	if ex == nil {
+		return ""
+	}
+	if ex.Left.Col.Name != "" {
+		return ex.Left.Col.Name
+	}
+	return ex.Left.ColName
+}
+
+func openAPIObjectValue(row map[string]any, name string) (any, bool) {
+	value, ok := row[name]
+	if ok {
+		return value, true
+	}
+	for key, candidate := range row {
+		if strings.EqualFold(key, name) {
+			return candidate, true
+		}
+	}
+	return nil, false
+}
+
+func openAPIExpScalar(ex *qcode.Exp, vars map[string]json.RawMessage) (any, error) {
+	if ex.Right.Table != "" || ex.Right.Col.Name != "" || ex.Right.ColName != "" {
+		return nil, fmt.Errorf("openapi where does not support column-reference operands")
+	}
+	switch ex.Right.ValType {
+	case qcode.ValVar:
+		return openAPIVar(ex.Right.Val, vars)
+	case qcode.ValNum:
+		return json.Number(ex.Right.Val), nil
+	case qcode.ValBool:
+		return strconv.ParseBool(ex.Right.Val)
+	case qcode.ValList:
+		return openAPIExpList(ex, vars)
+	default:
+		return ex.Right.Val, nil
+	}
+}
+
+func openAPIExpOptionalBool(ex *qcode.Exp, vars map[string]json.RawMessage, fallback bool) (bool, error) {
+	if ex.Right.Val == "" && ex.Right.ValType == 0 {
+		return fallback, nil
+	}
+	value, err := openAPIExpScalar(ex, vars)
+	if err != nil {
+		return false, err
+	}
+	switch value := value.(type) {
+	case bool:
+		return value, nil
+	case string:
+		return strconv.ParseBool(value)
+	default:
+		return false, fmt.Errorf("openapi where expects a boolean, got %T", value)
+	}
+}
+
+func openAPIExpList(ex *qcode.Exp, vars map[string]json.RawMessage) ([]any, error) {
+	if ex.Right.ValType == qcode.ValVar {
+		value, err := openAPIVar(ex.Right.Val, vars)
+		if err != nil {
+			return nil, err
+		}
+		list, ok := value.([]any)
+		if !ok {
+			return nil, fmt.Errorf("openapi variable %q must be a list", ex.Right.Val)
+		}
+		return list, nil
+	}
+	values := make([]any, 0, len(ex.Right.ListVal))
+	for _, raw := range ex.Right.ListVal {
+		switch ex.Right.ListType {
+		case qcode.ValNum:
+			values = append(values, json.Number(raw))
+		case qcode.ValBool:
+			value, err := strconv.ParseBool(raw)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+		default:
+			values = append(values, raw)
+		}
+	}
+	return values, nil
+}
+
+func openAPIVar(name string, vars map[string]json.RawMessage) (any, error) {
+	raw, ok := vars[name]
+	if !ok || len(raw) == 0 {
+		return nil, fmt.Errorf("openapi variable %q not found", name)
+	}
+	value, err := decodeOpenAPIJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("openapi variable %q: %w", name, err)
+	}
+	return value, nil
+}
+
+func sortOpenAPIRows(rows []map[string]any, orderBy []qcode.OrderBy) error {
+	if err := validateOpenAPIOrderBy(orderBy); err != nil {
+		return err
+	}
+	if len(orderBy) == 0 || len(rows) < 2 {
+		return nil
+	}
+	var sortErr error
+	sort.SliceStable(rows, func(i, j int) bool {
+		if sortErr != nil {
+			return false
+		}
+		for _, order := range orderBy {
+			left, leftOK := openAPIObjectValue(rows[i], order.Col.Name)
+			right, rightOK := openAPIObjectValue(rows[j], order.Col.Name)
+			leftNull := !leftOK || left == nil
+			rightNull := !rightOK || right == nil
+			if leftNull || rightNull {
+				if leftNull && rightNull {
+					continue
+				}
+				nullsFirst := order.Order == qcode.OrderAscNullsFirst || order.Order == qcode.OrderDescNullsFirst
+				if leftNull {
+					return nullsFirst
+				}
+				return !nullsFirst
+			}
+			cmp, err := compareOpenAPIValues(left, right)
+			if err != nil {
+				sortErr = fmt.Errorf("openapi order_by column %q: %w", order.Col.Name, err)
+				return false
+			}
+			if cmp == 0 {
+				continue
+			}
+			if openAPIOrderDesc(order.Order) {
+				return cmp > 0
+			}
+			return cmp < 0
+		}
+		return false
+	})
+	return sortErr
+}
+
+func validateOpenAPIOrderBy(orderBy []qcode.OrderBy) error {
+	for _, order := range orderBy {
+		if order.Alias != "" || order.Col.Name == "" || order.IsFunc ||
+			order.Key != "" || order.KeyVar != "" || order.Var != "" {
+			return fmt.Errorf("openapi order_by supports response columns only")
+		}
+	}
+	return nil
+}
+
+func openAPIOrderDesc(order qcode.Order) bool {
+	return order == qcode.OrderDesc || order == qcode.OrderDescNullsFirst || order == qcode.OrderDescNullsLast
+}
+
+func openAPIPage(sel *qcode.Select, vars map[string]json.RawMessage) (offset, limit int, err error) {
+	if sel == nil {
+		return 0, 0, nil
+	}
+	if sel.Paging.OffsetVar != "" {
+		offset, err = openAPIIntVar("offset", sel.Paging.OffsetVar, vars)
+		if err != nil {
+			return 0, 0, err
+		}
+	} else if sel.Paging.Offset > 0 {
+		offset = int(sel.Paging.Offset)
+	}
+	if sel.Paging.NoLimit {
+		return offset, 0, nil
+	}
+	if sel.Paging.LimitVar != "" {
+		limit, err = openAPIIntVar("limit", sel.Paging.LimitVar, vars)
+		return offset, limit, err
+	}
+	if sel.Paging.Limit > 0 {
+		limit = int(sel.Paging.Limit)
+	}
+	return offset, limit, nil
+}
+
+func openAPIIntVar(arg, name string, vars map[string]json.RawMessage) (int, error) {
+	value, err := openAPIVar(name, vars)
+	if err != nil {
+		return 0, err
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("openapi %s variable %q must be an integer", arg, name)
+	}
+	n, err := strconv.ParseInt(string(number), 10, 32)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("openapi %s variable %q must be a non-negative integer", arg, name)
+	}
+	return int(n), nil
+}
+
+func pageOpenAPIRows(rows []map[string]any, offset, limit int) []map[string]any {
+	if offset >= len(rows) {
+		return []map[string]any{}
+	}
+	if offset > 0 {
+		rows = rows[offset:]
+	}
+	if limit > 0 && limit < len(rows) {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
+func compareOpenAPIValues(left, right any) (int, error) {
+	if lf, ok := openAPINumber(left); ok {
+		rf, ok := openAPINumber(right)
+		if !ok {
+			return 0, fmt.Errorf("cannot compare number with %T", right)
+		}
+		switch {
+		case lf < rf:
+			return -1, nil
+		case lf > rf:
+			return 1, nil
+		default:
+			return 0, nil
+		}
+	}
+	switch value := left.(type) {
+	case string:
+		rightValue, ok := right.(string)
+		if !ok {
+			return 0, fmt.Errorf("cannot compare string with %T", right)
+		}
+		return strings.Compare(value, rightValue), nil
+	case bool:
+		rightValue, ok := right.(bool)
+		if !ok {
+			return 0, fmt.Errorf("cannot compare boolean with %T", right)
+		}
+		if value == rightValue {
+			return 0, nil
+		}
+		if !value {
+			return -1, nil
+		}
+		return 1, nil
+	default:
+		if openAPIEqual(left, right) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("values %T and %T are not orderable", left, right)
+	}
+}
+
+func openAPINumber(value any) (float64, bool) {
+	switch value := value.(type) {
+	case json.Number:
+		n, err := value.Float64()
+		return n, err == nil
+	case float64:
+		return value, true
+	case float32:
+		return float64(value), true
+	case int:
+		return float64(value), true
+	case int64:
+		return float64(value), true
+	case int32:
+		return float64(value), true
+	default:
+		return 0, false
+	}
+}
+
+func openAPIEqual(left, right any) bool {
+	if lf, ok := openAPINumber(left); ok {
+		rf, ok := openAPINumber(right)
+		return ok && lf == rf
+	}
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	switch leftValue := left.(type) {
+	case string:
+		rightValue, ok := right.(string)
+		return ok && leftValue == rightValue
+	case bool:
+		rightValue, ok := right.(bool)
+		return ok && leftValue == rightValue
+	case []any:
+		rightValue, ok := right.([]any)
+		if !ok || len(leftValue) != len(rightValue) {
+			return false
+		}
+		for i := range leftValue {
+			if !openAPIEqual(leftValue[i], rightValue[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		rightValue, ok := right.(map[string]any)
+		if !ok || len(leftValue) != len(rightValue) {
+			return false
+		}
+		for key, leftItem := range leftValue {
+			rightItem, exists := rightValue[key]
+			if !exists || !openAPIEqual(leftItem, rightItem) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func openAPILike(value, pattern string, insensitive bool) (bool, error) {
+	var b strings.Builder
+	b.WriteByte('^')
+	for _, r := range pattern {
+		switch r {
+		case '%':
+			b.WriteString(".*")
+		case '_':
+			b.WriteByte('.')
+		default:
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		}
+	}
+	b.WriteByte('$')
+	expr := b.String()
+	if insensitive {
+		expr = "(?i)" + expr
+	}
+	return regexp.MatchString(expr, value)
+}
+
+func openAPIContains(container, candidate any) bool {
+	switch container := container.(type) {
+	case string:
+		return strings.Contains(container, fmt.Sprint(candidate))
+	case []any:
+		candidateList, isList := candidate.([]any)
+		if !isList {
+			for _, value := range container {
+				if openAPIEqual(value, candidate) {
+					return true
+				}
+			}
+			return false
+		}
+		for _, wanted := range candidateList {
+			if !openAPIContains(container, wanted) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		candidateMap, ok := candidate.(map[string]any)
+		if !ok {
+			return false
+		}
+		for key, wanted := range candidateMap {
+			actual, exists := container[key]
+			if !exists || !openAPIEqual(actual, wanted) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func openAPIHasInCommon(left, right any) bool {
+	leftList, leftOK := left.([]any)
+	rightList, rightOK := right.([]any)
+	if !leftOK || !rightOK {
+		return false
+	}
+	for _, leftValue := range leftList {
+		for _, rightValue := range rightList {
+			if openAPIEqual(leftValue, rightValue) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func openAPIHasKey(value any, key string) bool {
+	switch value := value.(type) {
+	case map[string]any:
+		_, ok := value[key]
+		return ok
+	case []any:
+		index, err := strconv.Atoi(key)
+		return err == nil && index >= 0 && index < len(value)
+	default:
+		return false
+	}
+}

--- a/core/openapi_query_test.go
+++ b/core/openapi_query_test.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dosco/graphjin/core/v3/internal/qcode"
+	"github.com/dosco/graphjin/core/v3/internal/sdata"
+)
+
+func TestApplyOpenAPIQueryUsesPagingVariables(t *testing.T) {
+	body, err := applyOpenAPIQuery([]byte(`[{"id":1},{"id":2},{"id":3}]`), ResolverReq{
+		Sel: &qcode.Select{Paging: qcode.Paging{LimitVar: "take", OffsetVar: "skip"}},
+		Vars: map[string]json.RawMessage{
+			"take": json.RawMessage(`1`),
+			"skip": json.RawMessage(`1`),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(body), `[{"id":2}]`; got != want {
+		t.Fatalf("paged body = %s, want %s", got, want)
+	}
+}
+
+func TestApplyOpenAPIQueryRejectsUnsupportedArguments(t *testing.T) {
+	column := sdata.DBColumn{Name: "id"}
+	tests := []struct {
+		name string
+		sel  *qcode.Select
+		want string
+	}{
+		{
+			name: "distinct",
+			sel:  &qcode.Select{DistinctOn: []sdata.DBColumn{column}},
+			want: "distinct is not supported",
+		},
+		{
+			name: "cursor pagination",
+			sel:  &qcode.Select{Paging: qcode.Paging{Cursor: true}},
+			want: "cursor pagination is not supported",
+		},
+		{
+			name: "configured order variant",
+			sel: &qcode.Select{OrderBy: []qcode.OrderBy{{
+				Col: column, Order: qcode.OrderAsc, KeyVar: "sort",
+			}}},
+			want: "order_by supports response columns only",
+		},
+		{
+			name: "unsupported where operator",
+			sel: &qcode.Select{Where: qcode.Filter{Exp: &qcode.Exp{
+				Op: qcode.OpTsQuery,
+			}}},
+			want: "where does not support operator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := applyOpenAPIQuery([]byte(`[]`), ResolverReq{Sel: tt.sel})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyOpenAPIQueryRejectsColumnReferenceFilter(t *testing.T) {
+	ex := &qcode.Exp{Op: qcode.OpEquals}
+	ex.Left.Col = sdata.DBColumn{Name: "id"}
+	ex.Right.Col = sdata.DBColumn{Name: "other_id"}
+
+	_, err := applyOpenAPIQuery([]byte(`[{}]`), ResolverReq{
+		Sel: &qcode.Select{Where: qcode.Filter{Exp: ex}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "column-reference operands") {
+		t.Fatalf("error = %v, want column-reference rejection", err)
+	}
+}

--- a/core/remote_join.go
+++ b/core/remote_join.go
@@ -34,24 +34,29 @@ func (s *gstate) execRemoteJoin(c context.Context) (err error) {
 		return
 	}
 
-	to, extra, err := s.resolveRemotes(c, from, sfmap, s.requestedRootCursorFields())
-	if err != nil {
-		return
+	to, extra, resolveErr := s.resolveRemotes(c, from, sfmap, s.requestedRootCursorFields())
+	if len(to) != len(from) {
+		// Resolver lookup/marker failures are structural rather than per-field
+		// upstream failures, so there is no trustworthy replacement plan.
+		return resolveErr
 	}
 
 	var ob bytes.Buffer
 	if err = jsn.Replace(&ob, s.data, from, to); err != nil {
-		return
+		return errors.Join(resolveErr, err)
 	}
 	s.data = ob.Bytes()
 	if len(extra) != 0 {
 		if s.data, err = mergeRemoteRootFields(s.data, extra); err != nil {
-			return
+			return errors.Join(resolveErr, err)
 		}
 		s.dhash = sha256.Sum256(s.data)
 		s.data, err = encryptValues(s.data, s.gj.printFormat, decPrefix, s.dhash[:], s.gj.encryptionKey)
+		if err != nil {
+			return errors.Join(resolveErr, err)
+		}
 	}
-	return
+	return resolveErr
 }
 
 // resolveRemotes fetches remote data for the marked insertion points
@@ -72,8 +77,7 @@ func (s *gstate) resolveRemotes(
 	var wg sync.WaitGroup
 	wg.Add(len(from))
 
-	var cerr error
-	var cerrMutex sync.Mutex
+	resolveErrs := make([]error, len(from))
 
 	for i, id := range from {
 		// use the json key to find the related Select object
@@ -106,6 +110,10 @@ func (s *gstate) resolveRemotes(
 		if !ok {
 			return nil, nil, fmt.Errorf("no resolver found for remote %q", rkey)
 		}
+		// GraphQL partial-result semantics: a resolver failure nulls only its
+		// own field. Successful sibling roots and sibling rows are still merged
+		// into the response after every concurrent request finishes.
+		to[i] = jsn.Field{Key: []byte(sel.FieldName), Value: []byte("null")}
 
 		go func(n int, id []byte, sel *qcode.Select, r resItem, rkey string) {
 			defer wg.Done()
@@ -170,10 +178,8 @@ func (s *gstate) resolveRemotes(
 			start := time.Now()
 			b, refs, cursor, err := produce(ctx1)
 			if err != nil {
-				cerrMutex.Lock()
-				cerr = fmt.Errorf("%s: %s", sel.Table, err)
-				spanErr := cerr
-				cerrMutex.Unlock()
+				spanErr := fmt.Errorf("remote field %s: %w", sel.FieldName, err)
+				resolveErrs[n] = spanErr
 				span.Error(spanErr)
 				return
 			}
@@ -192,7 +198,7 @@ func (s *gstate) resolveRemotes(
 		}(i, rid, sel, r, rkey)
 	}
 	wg.Wait()
-	return to, extra, cerr
+	return to, extra, errors.Join(resolveErrs...)
 }
 
 func (s *gstate) requestedRootCursorFields() map[string]struct{} {

--- a/serv/config.schema.json
+++ b/serv/config.schema.json
@@ -1879,6 +1879,10 @@
 				"concurrency": {
 					"$ref": "#/$defs/ConcurrencyConfig"
 				},
+				"timeout": {
+					"type": "integer",
+					"title": "Upstream Request Timeout"
+				},
 				"max_request_bytes": {
 					"type": "integer"
 				},

--- a/serv/config_test.go
+++ b/serv/config_test.go
@@ -4,7 +4,26 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestNewConfigParsesOpenAPITimeout(t *testing.T) {
+	conf, err := NewConfig(`
+mode: dev
+sources:
+  - name: upstream
+    kind: api
+    specs:
+      billing:
+        timeout: 5s
+`, "yaml")
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	if got := conf.Core.Sources[0].Specs["billing"].Timeout; got != 5*time.Second {
+		t.Fatalf("OpenAPI timeout = %s, want 5s", got)
+	}
+}
 
 func TestNewConfigCatalogEnabledAuto(t *testing.T) {
 	conf, err := NewConfig(`

--- a/serv/mcp_config.go
+++ b/serv/mcp_config.go
@@ -1771,6 +1771,7 @@ func sourceConfigInputSchema(required []string) map[string]any {
 				"type": "object",
 				"properties": map[string]any{
 					"base_url":           map[string]any{"type": "string"},
+					"timeout":            map[string]any{"type": "integer", "minimum": 0, "description": "Upstream timeout in nanoseconds (Go duration); YAML accepts values such as 5s"},
 					"max_request_bytes":  map[string]any{"type": "integer", "minimum": 0},
 					"max_response_bytes": map[string]any{"type": "integer", "minimum": 0},
 					"operations": map[string]any{

--- a/serv/mcp_syntax.go
+++ b/serv/mcp_syntax.go
@@ -340,6 +340,7 @@ var querySyntaxReference = QuerySyntaxReference{
 		RemoteJoins: []QueryExample{
 			{Description: "Query with remote API join (resolver)", Query: "{ users { email payments { desc amount } } }"},
 			{Description: "Remote join - resolver fetches data from external API using DB column as $id", Query: "{ customers(limit: 10) { name stripe_subscriptions { plan status } } }"},
+			{Description: "Filter, order, and page an OpenAPI virtual table", Query: "{ alerts(where: { severity: { eq: \"critical\" } }, order_by: { warningCount: desc }, limit: 10) { id severity warningCount } }"},
 		},
 	},
 }

--- a/serv/mcp_test.go
+++ b/serv/mcp_test.go
@@ -1658,6 +1658,16 @@ func TestQuerySyntaxReference_HasRemoteJoins(t *testing.T) {
 			t.Error("Expected query for remote join example")
 		}
 	}
+	foundOpenAPIFilter := false
+	for _, example := range querySyntaxReference.Examples.RemoteJoins {
+		if strings.Contains(example.Description, "OpenAPI") && strings.Contains(example.Query, "where:") {
+			foundOpenAPIFilter = true
+			break
+		}
+	}
+	if !foundOpenAPIFilter {
+		t.Error("Expected OpenAPI filtering example in remote join syntax reference")
+	}
 }
 
 func TestQuerySyntaxReference_HasBothAggregateForms(t *testing.T) {

--- a/tests/openapi_query_regression_test.go
+++ b/tests/openapi_query_regression_test.go
@@ -1,0 +1,252 @@
+package tests_test
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dosco/graphjin/core/v3"
+	"github.com/dosco/graphjin/core/v3/openapi"
+	"github.com/dosco/graphjin/serv/v3"
+)
+
+func openAPIQueryRegressionConfig(t *testing.T, databaseType, upstreamURL string, timeout time.Duration) *core.Config {
+	t.Helper()
+	specsDir := t.TempDir()
+	spec := fmt.Sprintf(`
+openapi: "3.0.0"
+info: { title: Query Regression, version: "1.0.0" }
+servers: [{ url: %s }]
+paths:
+  /alerts:
+    get:
+      operationId: listAlerts
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    severity: { type: string }
+                    warningCount: { type: integer }
+  /projects/{id}:
+    get:
+      operationId: getProject
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  warningCount: { type: integer }
+`, upstreamURL)
+	if err := os.WriteFile(filepath.Join(specsDir, "regression.yaml"), []byte(spec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return newConfig(&core.Config{
+		Mode:                 "dev",
+		DBType:               databaseType,
+		DisableAllowList:     true,
+		DBSchemaPollDuration: -1,
+		DefaultLimit:         10,
+		Sources: []core.SourceConfig{
+			{Name: core.DefaultDBName, Kind: "database", Type: databaseType, Default: true, Access: core.SourceAccessConfig{Read: core.AccessModePublic}},
+			{
+				Name: "upstream", Kind: "api", SpecsDir: specsDir,
+				Access: core.SourceAccessConfig{Read: core.AccessModePublic},
+				Specs: map[string]openapi.SpecConfig{
+					"regression": {
+						Timeout: timeout,
+						Joins: map[string]openapi.JoinConfig{
+							"getProject": {ParentTable: "users", ParentColumn: "id", Param: "id", ExposeAs: "live"},
+						},
+						Operations: map[string]openapi.OperationOverride{
+							"listAlerts": {ExposeAs: "alerts"},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestOpenAPIWhereOrderAndPagingAreApplied(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/alerts" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"id":"a1","severity":"critical","warningCount":5},
+			{"id":"a2","severity":"warning","warningCount":9},
+			{"id":"a3","severity":"critical","warningCount":3},
+			{"id":"a4","severity":"critical","warningCount":1}
+		]`)
+	}))
+	defer upstream.Close()
+
+	gj, err := core.NewGraphJin(openAPIQueryRegressionConfig(t, dbType, upstream.URL, time.Second), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gj.Close()
+
+	vars := json.RawMessage(`{"severity":"critical","minimum":1}`)
+	res, err := gj.GraphQL(sourceModeIntegrationUserContext(), `query FilterAlerts(
+		$severity: String!, $minimum: Int!
+	) {
+		alerts(
+			where: {severity: {eq: $severity}, warningCount: {gt: $minimum}}
+			order_by: {warningCount: desc}
+			offset: 1
+			limit: 1
+		) { id severity warningCount }
+	}`, vars, nil)
+	if err != nil || len(res.Errors) != 0 {
+		t.Fatalf("filtered OpenAPI query: err=%v errors=%+v data=%s", err, res.Errors, res.Data)
+	}
+	if got, want := string(res.Data), `{"alerts":[{"id":"a3","severity":"critical","warningCount":3}]}`; got != want {
+		t.Fatalf("filtered OpenAPI response = %s, want %s", got, want)
+	}
+}
+
+func TestOpenAPIRowJoinWhereNullsNonMatchingObject(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/projects/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"project","warningCount":2}`)
+	}))
+	defer upstream.Close()
+
+	gj, err := core.NewGraphJin(openAPIQueryRegressionConfig(t, dbType, upstream.URL, time.Second), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gj.Close()
+
+	res, err := gj.GraphQL(sourceModeIntegrationUserContext(), `query {
+		users(limit: 1, order_by: {id: asc}) {
+			id
+			live(where: {warningCount: {gt: 999}}) { id warningCount }
+		}
+	}`, nil, nil)
+	if err != nil || len(res.Errors) != 0 {
+		t.Fatalf("row-join filter: err=%v errors=%+v data=%s", err, res.Errors, res.Data)
+	}
+	var data struct {
+		Users []struct {
+			Live json.RawMessage `json:"live"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(res.Data, &data); err != nil {
+		t.Fatal(err)
+	}
+	if len(data.Users) != 1 || string(data.Users[0].Live) != "null" {
+		t.Fatalf("non-matching row join must be null: %s", res.Data)
+	}
+}
+
+func TestOpenAPITimeoutReturnsHTTPPartialDataAndError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/alerts" {
+			http.NotFound(w, r)
+			return
+		}
+		<-r.Context().Done()
+	}))
+	defer upstream.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "app.sqlite")
+	appDB, err := sql.Open("sqlite3_regexp", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := appDB.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT); INSERT INTO users VALUES (1, 'healthy@example.com')`); err != nil {
+		_ = appDB.Close()
+		t.Fatal(err)
+	}
+
+	conf := openAPIQueryRegressionConfig(t, "sqlite", upstream.URL, 40*time.Millisecond)
+	gjs, err := serv.NewGraphJinService(&serv.Config{
+		Core: *conf,
+		Serv: serv.Serv{ConfigPath: t.TempDir(), MCP: serv.MCPConfig{Disable: true}},
+	}, serv.OptionSetDB(appDB))
+	if err != nil {
+		_ = appDB.Close()
+		t.Fatal(err)
+	}
+	defer gjs.Close()
+
+	payload, _ := json.Marshal(map[string]any{"query": `query {
+		users(limit: 1, order_by: {id: asc}) { id email }
+		alerts { id severity }
+	}`})
+	server := httptest.NewUnstartedServer(gjs.GraphQL(nil))
+	server.Config.WriteTimeout = 100 * time.Millisecond
+	server.Start()
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/graphql", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("GraphQL HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) == 0 {
+		t.Fatal("timed-out OpenAPI root returned an empty HTTP body")
+	}
+	var response struct {
+		Data struct {
+			Users []struct {
+				Email string `json:"email"`
+			} `json:"users"`
+			Alerts json.RawMessage `json:"alerts"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode GraphQL HTTP response: %v\n%s", err, body)
+	}
+	if len(response.Data.Users) != 1 || response.Data.Users[0].Email != "healthy@example.com" {
+		t.Fatalf("healthy database root was not preserved: %s", body)
+	}
+	if string(response.Data.Alerts) != "null" {
+		t.Fatalf("failed OpenAPI root must be null: %s", body)
+	}
+	if len(response.Errors) != 1 || !strings.Contains(response.Errors[0].Message, "timed out") {
+		t.Fatalf("timeout must surface as a GraphQL error: %s", body)
+	}
+}

--- a/tests/openapi_query_regression_test.go
+++ b/tests/openapi_query_regression_test.go
@@ -89,6 +89,18 @@ paths:
 	})
 }
 
+func skipOpenAPIQueryRegressionForUnscopedFixture(t *testing.T, conf *core.Config) {
+	t.Helper()
+	// Some non-relational suites describe their shared fixture with unscoped
+	// tables. GraphJin correctly rejects those tables once an API source is also
+	// configured, before these OpenAPI response semantics can be exercised.
+	for _, table := range conf.Tables {
+		if strings.TrimSpace(table.Source) == "" {
+			t.Skipf("%s: shared fixture declares table %q without a source, which cannot coexist with an api source", dbType, table.Name)
+		}
+	}
+}
+
 func TestOpenAPIWhereOrderAndPagingAreApplied(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/alerts" {
@@ -105,7 +117,9 @@ func TestOpenAPIWhereOrderAndPagingAreApplied(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	gj, err := core.NewGraphJin(openAPIQueryRegressionConfig(t, dbType, upstream.URL, time.Second), db)
+	conf := openAPIQueryRegressionConfig(t, dbType, upstream.URL, time.Second)
+	skipOpenAPIQueryRegressionForUnscopedFixture(t, conf)
+	gj, err := core.NewGraphJin(conf, db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +155,9 @@ func TestOpenAPIRowJoinWhereNullsNonMatchingObject(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	gj, err := core.NewGraphJin(openAPIQueryRegressionConfig(t, dbType, upstream.URL, time.Second), db)
+	conf := openAPIQueryRegressionConfig(t, dbType, upstream.URL, time.Second)
+	skipOpenAPIQueryRegressionForUnscopedFixture(t, conf)
+	gj, err := core.NewGraphJin(conf, db)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/website/content/configure/openapi-config.md
+++ b/website/content/configure/openapi-config.md
@@ -16,6 +16,7 @@ sources:
     specs:
       stripe:
         base_url: https://api.stripe.com
+        timeout: 5s
         auth:
           scheme: bearer
           token: ${STRIPE_TOKEN}
@@ -23,6 +24,11 @@ sources:
           max_concurrent: 8
           rate_limit_per_second: 20
 ```
+
+`timeout` bounds the complete upstream operation, including authentication,
+retries, and response reads. It defaults to `8s`. A timed-out API field is
+returned as `null` with a GraphQL error while successful sibling roots remain
+available in `data`.
 
 ## Supported auth schemes
 
@@ -85,3 +91,24 @@ query ($id: ID!) {
 ```
 
 Top-level operations appear as virtual root fields when classified or explicitly exposed. Unsupported operations are skipped with boot-time diagnostics instead of half-registering a broken field.
+
+OpenAPI list roots and row-join objects accept the common `where`, `order_by`,
+`limit`, and `offset` arguments. GraphJin applies these to the returned JSON,
+while operation-specific path and query parameters are sent to the upstream:
+
+```graphql
+query {
+  payments_api(
+    where: { status: { eq: "failed" } }
+    order_by: { created_at: desc }
+    limit: 20
+  ) {
+    id
+    status
+    created_at
+  }
+}
+```
+
+Unsupported filter operators fail explicitly. API response fields do not
+support cursor pagination or `distinct`; use `limit` and `offset` for paging.


### PR DESCRIPTION
## Summary

- apply where, order_by, limit, and offset to OpenAPI list and object responses, while rejecting unsupported API-source query semantics explicitly
- add a bounded per-spec upstream timeout and preserve successful GraphQL sibling data when an API resolver fails
- document the behavior and add unit, config, MCP, HTTP, and cross-dialect regression coverage

## Validation

- core: go test ./... -count=1
- core race: go test -race ./... -count=1
- service: go test ./... -count=1
- full PostgreSQL, MySQL, SQLite, MongoDB, MSSQL, and Oracle dialect suites
- focused OpenAPI regressions on all six dialects after the final hot-path cleanup
- cmd: go build ./...

Fixes #613
Fixes #614
