### PR TITLE
fix: honor database TLS and scope MSSQL identifiers

### DIFF
--- a/core/internal/dialect/dialect.go
+++ b/core/internal/dialect/dialect.go
@@ -204,6 +204,14 @@ type NameMapSetter interface {
 	SetNameMap(tables []sdata.DBTable)
 }
 
+// ScopedColumnQuoter is implemented by dialects whose normalized GraphQL
+// column names are not sufficient to recover a physical identifier globally.
+// SQL Server schemas can use multiple spellings such as FlagValue and
+// Flag_Value across different tables, so column lookup must include the table.
+type ScopedColumnQuoter interface {
+	QuoteColumn(table, column string) string
+}
+
 // FullQueryCompiler is an optional interface that dialects can implement
 // to handle entire query compilation themselves (bypassing SQL generation).
 // This is used by MongoDB which generates JSON query DSL, not SQL.

--- a/core/internal/dialect/mssql.go
+++ b/core/internal/dialect/mssql.go
@@ -2,6 +2,7 @@ package dialect
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/dosco/graphjin/core/v3/internal/graph"
@@ -81,7 +82,8 @@ import (
 type MSSQLDialect struct {
 	DBVersion       int
 	EnableCamelcase bool
-	NameMap         map[string]string // normalized→original identifier mapping
+	NameMap         map[string]string            // normalized→original identifier mapping
+	ColumnNameMap   map[string]map[string]string // normalized table→column→original column
 }
 
 func (d *MSSQLDialect) Name() string {
@@ -97,9 +99,39 @@ func (d *MSSQLDialect) QuoteIdentifier(s string) string {
 	return "[" + s + "]"
 }
 
+// QuoteColumn resolves a normalized GraphQL column name within its table.
+// A global normalized→original map is insufficient because distinct physical
+// spellings such as FlagValue and Flag_Value both normalize to flag_value.
+func (d *MSSQLDialect) QuoteColumn(table, column string) string {
+	lookupTable := table
+	if _, ok := d.ColumnNameMap[lookupTable]; !ok {
+		if split := strings.LastIndexByte(lookupTable, '_'); split > 0 {
+			if _, err := strconv.Atoi(lookupTable[split+1:]); err == nil {
+				lookupTable = lookupTable[:split]
+			}
+		}
+	}
+	if columns, ok := d.ColumnNameMap[lookupTable]; ok {
+		if original, ok := columns[column]; ok {
+			return "[" + original + "]"
+		}
+	}
+	return d.QuoteIdentifier(column)
+}
+
 // SetNameMap builds a normalized→original name mapping from discovered tables.
 func (d *MSSQLDialect) SetNameMap(tables []sdata.DBTable) {
 	d.NameMap = make(map[string]string)
+	d.ColumnNameMap = make(map[string]map[string]string)
+	setScoped := func(table, normalized, original string) {
+		if table == "" || normalized == "" || original == "" {
+			return
+		}
+		if d.ColumnNameMap[table] == nil {
+			d.ColumnNameMap[table] = make(map[string]string)
+		}
+		d.ColumnNameMap[table][normalized] = original
+	}
 	for _, t := range tables {
 		if t.OrigName != "" && t.OrigName != t.Name {
 			d.NameMap[t.Name] = t.OrigName
@@ -108,6 +140,8 @@ func (d *MSSQLDialect) SetNameMap(tables []sdata.DBTable) {
 			d.NameMap[t.Schema] = t.OrigSchema
 		}
 		for _, c := range t.Columns {
+			setScoped(t.Name, c.Name, c.OrigName)
+			setScoped(c.FKeyTable, c.FKeyCol, c.OrigFKeyCol)
 			if c.OrigName != "" && c.OrigName != c.Name {
 				d.NameMap[c.Name] = c.OrigName
 			}

--- a/core/internal/psql/mssql_identifier_mapping_test.go
+++ b/core/internal/psql/mssql_identifier_mapping_test.go
@@ -1,0 +1,71 @@
+package psql_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/dosco/graphjin/core/v3/internal/psql"
+	"github.com/dosco/graphjin/core/v3/internal/qcode"
+	"github.com/dosco/graphjin/core/v3/internal/sdata"
+)
+
+// TestMSSQLIdentifierMappingIsScopedByTable guards #571 with a deliberately
+// synthetic schema. The columns normalize to the same GraphQL names even
+// though their physical SQL Server identifiers use incompatible spellings.
+// The renderer must recover each name from its selected table.
+func TestMSSQLIdentifierMappingIsScopedByTable(t *testing.T) {
+	cols := []sdata.DBColumn{
+		{Schema: "dbo", Table: "synthetic_alpha", OrigSchema: "dbo", OrigTable: "SyntheticAlpha", Name: "row_id", OrigName: "Row_ID", Type: "int", PrimaryKey: true, UniqueKey: true},
+		{Schema: "dbo", Table: "synthetic_alpha", OrigSchema: "dbo", OrigTable: "SyntheticAlpha", Name: "flag_value", OrigName: "Flag_Value", Type: "bit"},
+		{Schema: "dbo", Table: "synthetic_alpha", OrigSchema: "dbo", OrigTable: "SyntheticAlpha", Name: "parent_id", OrigName: "parent_id", Type: "int"},
+		{Schema: "dbo", Table: "synthetic_alpha", OrigSchema: "dbo", OrigTable: "SyntheticAlpha", Name: "payload_kind", OrigName: "Payload_Kind", Type: "nvarchar"},
+		{Schema: "dbo", Table: "synthetic_beta", OrigSchema: "dbo", OrigTable: "SyntheticBeta", Name: "row_id", OrigName: "RowID", Type: "int", PrimaryKey: true, UniqueKey: true},
+		{Schema: "dbo", Table: "synthetic_beta", OrigSchema: "dbo", OrigTable: "SyntheticBeta", Name: "flag_value", OrigName: "FlagValue", Type: "bit"},
+		{Schema: "dbo", Table: "synthetic_beta", OrigSchema: "dbo", OrigTable: "SyntheticBeta", Name: "parent_id", OrigName: "parentId", Type: "int"},
+	}
+
+	info := sdata.NewDBInfo("mssql", 2022, "dbo", "db", cols, nil, nil)
+	schema, err := sdata.NewDBSchema(info, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	qc, err := qcode.NewCompiler(schema, qcode.Config{DBSchema: "dbo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for table, allowed := range map[string][]string{
+		"synthetic_alpha": {"row_id", "flag_value", "parent_id", "payload_kind"},
+		"synthetic_beta":  {"row_id", "flag_value", "parent_id"},
+	} {
+		if err := qc.AddRole("user", "dbo", table, qcode.TRConfig{Query: qcode.QueryConfig{Columns: allowed}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	compiled, err := qc.Compile([]byte(`query {
+		synthetic_alpha { flag_value parent_id payload_kind }
+		synthetic_beta { flag_value parent_id }
+	}`), nil, "user", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := psql.NewCompiler(psql.Config{DBType: "mssql", DBVersion: 2022})
+	pc.SetSchemaInfo(schema.GetTables())
+	_, sqlBytes, err := pc.CompileEx(compiled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(sqlBytes)
+
+	for _, want := range []string{
+		`\[synthetic_alpha_[0-9]+\]\.\[Flag_Value\]`,
+		`\[synthetic_alpha_[0-9]+\]\.\[parent_id\]`,
+		`\[synthetic_alpha_[0-9]+\]\.\[Payload_Kind\]`,
+		`\[synthetic_beta_[0-9]+\]\.\[FlagValue\]`,
+		`\[synthetic_beta_[0-9]+\]\.\[parentId\]`,
+	} {
+		if !regexp.MustCompile(want).MatchString(sql) {
+			t.Fatalf("MSSQL SQL missing table-scoped identifier %q:\n%s", want, sql)
+		}
+	}
+}

--- a/core/internal/psql/util.go
+++ b/core/internal/psql/util.go
@@ -24,7 +24,7 @@ func (c *compilerContext) colWithTableID(table string, id int32, col string) {
 		c.quoted(table)
 	}
 	c.w.WriteString(`.`)
-	c.quoted(col)
+	c.quotedColumn(table, col)
 }
 
 func (c *compilerContext) table(sel *qcode.Select, schema, table string, alias bool) {
@@ -41,7 +41,15 @@ func (c *compilerContext) table(sel *qcode.Select, schema, table string, alias b
 func (c *compilerContext) colWithTable(table, col string) {
 	c.quoted(table)
 	c.w.WriteString(`.`)
-	c.quoted(col)
+	c.quotedColumn(table, col)
+}
+
+func (c *compilerContext) quotedColumn(table, column string) {
+	if quoter, ok := c.dialect.(dialect.ScopedColumnQuoter); ok {
+		c.w.WriteString(quoter.QuoteColumn(table, column))
+		return
+	}
+	c.quoted(column)
 }
 
 func (c *compilerContext) quoted(identifier string) {

--- a/serv/init.go
+++ b/serv/init.go
@@ -453,58 +453,95 @@ func (s *graphjinService) newDBFromDatabaseConfigInto(name string, dbConf core.D
 		pingTimeout = 30 * time.Second
 	}
 
-	// For SQLite, just use tryConnect directly
-	if dbType == "sqlite" {
-		path := dbConf.Path
-		if path == "" {
-			path = dbConf.ConnString
-		}
-		if path == "" {
-			return nil, fmt.Errorf("sqlite database '%s' requires a path or connection_string", name)
-		}
-		return tryConnect("sqlite", path, pingTimeout)
+	// A raw connection string already defines its database. Preserve it exactly
+	// as the previous multi-database path did; openDB only applies DBName when
+	// the connection is assembled from individual fields.
+	openDB := dbConf.ConnString == ""
+	if openDB && dbConf.DBName == "" && dbType != "sqlite" {
+		dbConf.DBName = name
 	}
-
-	// Build connection using probe helpers (reuses mcp_discover.go logic)
-	host := dbConf.Host
-	port := dbConf.Port
-	user := dbConf.User
-	password := dbConf.Password
-	dbName := dbConf.DBName
-	if dbName == "" {
-		dbName = name
+	conf := configuredDatabaseServiceConfig(dbType, dbConf)
+	fs := s.fs
+	if fs == nil {
+		fs = core.NewOsFS("")
 	}
+	driver, err := initDBDriver(conf, openDB, false, fs)
+	if err != nil {
+		return nil, err
+	}
+	return connectConfiguredDatabase(driver, conf.DB, pingTimeout)
+}
 
-	// Snowflake with key pair auth needs the connector path
-	if dbType == "snowflake" && (dbConf.PrivateKeyPath != "" || dbConf.PrivateKeyPEM != "") {
-		conf := &Config{}
-		conf.DB.ConnString = dbConf.ConnString
-		conf.DB.PrivateKeyPath = dbConf.PrivateKeyPath
-		conf.DB.PrivateKeyPEM = dbConf.PrivateKeyPEM
-		conf.DB.KeyPassphrase = dbConf.KeyPassphrase
-		dc, err := initSnowflake(conf, true, false, core.NewOsFS(""))
+// configuredDatabaseServiceConfig converts the multi-database core shape into
+// the service driver shape. Keeping this path on initDBDriver ensures TLS,
+// database-specific encryption, key-pair auth, and connector-backed drivers
+// behave exactly like the legacy single-database configuration.
+func configuredDatabaseServiceConfig(dbType string, dbConf core.DatabaseConfig) *Config {
+	poolSize := dbConf.PoolSize
+	if poolSize == 0 {
+		poolSize = dbConf.MaxIdleConns
+	}
+	maxConnections := dbConf.MaxConnections
+	if maxConnections == 0 {
+		maxConnections = dbConf.MaxOpenConns
+	}
+	return &Config{
+		Core: core.Config{DBType: dbType},
+		Serv: Serv{DB: Database{
+			Type:                   dbType,
+			ConnString:             dbConf.ConnString,
+			Host:                   dbConf.Host,
+			Port:                   uint16(dbConf.Port),
+			DBName:                 dbConf.DBName,
+			User:                   dbConf.User,
+			Password:               dbConf.Password,
+			Schema:                 dbConf.Schema,
+			Path:                   dbConf.Path,
+			PoolSize:               poolSize,
+			MaxConnections:         maxConnections,
+			MaxConnIdleTime:        dbConf.MaxConnIdleTime,
+			MaxConnLifeTime:        dbConf.MaxConnLifeTime,
+			PingTimeout:            dbConf.PingTimeout,
+			EnableTLS:              dbConf.EnableTLS,
+			ServerName:             dbConf.ServerName,
+			ServerCert:             dbConf.ServerCert,
+			ClientCert:             dbConf.ClientCert,
+			ClientKey:              dbConf.ClientKey,
+			Encrypt:                dbConf.Encrypt,
+			TrustServerCertificate: dbConf.TrustServerCertificate,
+			PrivateKeyPath:         dbConf.PrivateKeyPath,
+			PrivateKeyPEM:          dbConf.PrivateKeyPEM,
+			KeyPassphrase:          dbConf.KeyPassphrase,
+		}},
+	}
+}
+
+func connectConfiguredDatabase(driver *dbConf, conf Database, timeout time.Duration) (*sql.DB, error) {
+	var (
+		db  *sql.DB
+		err error
+	)
+	if driver.connector != nil {
+		db = sql.OpenDB(driver.connector)
+	} else {
+		db, err = sql.Open(driver.driverName, driver.connString)
 		if err != nil {
 			return nil, err
 		}
-		return sql.OpenDB(dc.connector), nil
 	}
 
-	if dbConf.ConnString != "" {
-		// Use connection string directly
-		driverName := driverForType(dbType)
-		if dbType == "postgres" {
-			driverName, _ = buildProbeConnString(dbType, "", 0, "", "", "", "tcp", dbName)
-			// Fall back to raw conn string
-			return tryConnect("pgx", dbConf.ConnString, pingTimeout)
-		}
-		return tryConnect(driverName, dbConf.ConnString, pingTimeout)
-	}
+	db.SetMaxIdleConns(conf.PoolSize)
+	db.SetMaxOpenConns(conf.MaxConnections)
+	db.SetConnMaxIdleTime(conf.MaxConnIdleTime)
+	db.SetConnMaxLifetime(conf.MaxConnLifeTime)
 
-	driverName, connString := buildProbeConnString(dbType, host, port, "", user, password, "tcp", dbName)
-	if connString == "" {
-		return nil, fmt.Errorf("could not build connection string for database '%s' (type=%s)", name, dbType)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		db.Close() //nolint:errcheck
+		return nil, err
 	}
-	return tryConnect(driverName, connString, pingTimeout)
+	return db, nil
 }
 
 // driverForType returns the Go SQL driver name for a database type.

--- a/serv/init_test.go
+++ b/serv/init_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dosco/graphjin/core/v3"
 	"github.com/stretchr/testify/assert"
@@ -163,6 +164,39 @@ func Handler() {}
 	require.NotNil(t, s.dbs["code"])
 	assert.Equal(t, "sqlite", s.runtimeCore.Databases["code"].Type)
 	assert.Equal(t, "codesql", s.conf.Core.Databases["code"].Type)
+}
+
+// TestNewDBFromDatabaseConfigHonorsPostgresTLSValidation guards #564. The
+// configured multi-database path must pass TLS fields through the same driver
+// initializer as the legacy single-database path. Missing required TLS fields
+// must therefore fail before GraphJin attempts a plaintext connection.
+func TestNewDBFromDatabaseConfigHonorsPostgresTLSValidation(t *testing.T) {
+	s := &graphjinService{
+		conf:       &Config{},
+		fs:         core.NewOsFS(""),
+		managedDBs: make(map[string]managedDB),
+	}
+
+	base := core.DatabaseConfig{
+		Type:        "postgres",
+		Host:        "127.0.0.1",
+		Port:        1,
+		DBName:      "analytics",
+		User:        "graphjin",
+		Password:    "secret",
+		EnableTLS:   true,
+		PingTimeout: time.Millisecond,
+	}
+	t.Run("server name", func(t *testing.T) {
+		_, err := s.newDBFromDatabaseConfig("analytics", base)
+		require.ErrorContains(t, err, "tls: server_name is required")
+	})
+	t.Run("server certificate", func(t *testing.T) {
+		conf := base
+		conf.ServerName = "analytics.example.com"
+		_, err := s.newDBFromDatabaseConfig("analytics", conf)
+		require.ErrorContains(t, err, "tls: server_cert is required")
+	})
 }
 
 // newTestLogger creates a no-op logger for testing

--- a/tests/mssql_dialect_test.go
+++ b/tests/mssql_dialect_test.go
@@ -125,6 +125,74 @@ func TestMSSQLPascalCaseNaming(t *testing.T) {
 	})
 }
 
+// TestMSSQLMixedColumnSpellingsStayTableScoped is the live regression for
+// #571. Both tables expose the same normalized GraphQL names while their
+// physical SQL Server identifiers use incompatible spellings.
+func TestMSSQLMixedColumnSpellingsStayTableScoped(t *testing.T) {
+	if dbType != "mssql" {
+		t.Skipf("skipping MSSQL naming test for %s", dbType)
+	}
+	stmts := []string{
+		`IF OBJECT_ID('SyntheticBeta','U') IS NOT NULL DROP TABLE SyntheticBeta`,
+		`IF OBJECT_ID('SyntheticAlpha','U') IS NOT NULL DROP TABLE SyntheticAlpha`,
+		`CREATE TABLE SyntheticAlpha (
+			Row_ID INT PRIMARY KEY,
+			Flag_Value BIT NOT NULL,
+			parent_id INT NOT NULL,
+			Payload_Kind NVARCHAR(100) NOT NULL
+		)`,
+		`CREATE TABLE SyntheticBeta (
+			RowID INT PRIMARY KEY,
+			FlagValue BIT NOT NULL,
+			parentId INT NOT NULL
+		)`,
+		`INSERT INTO SyntheticAlpha (Row_ID, Flag_Value, parent_id, Payload_Kind)
+		 VALUES (1, 1, 41, N'alpha')`,
+		`INSERT INTO SyntheticBeta (RowID, FlagValue, parentId)
+		 VALUES (1, 0, 73)`,
+	}
+	for _, stmt := range stmts {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err, "fixture setup: %s", stmt)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(`IF OBJECT_ID('SyntheticBeta','U') IS NOT NULL DROP TABLE SyntheticBeta`)
+		_, _ = db.Exec(`IF OBJECT_ID('SyntheticAlpha','U') IS NOT NULL DROP TABLE SyntheticAlpha`)
+	})
+
+	conf := newConfig(&core.Config{DBType: dbType, DisableAllowList: true})
+	gj, err := core.NewGraphJin(conf, db)
+	require.NoError(t, err)
+	defer gj.Close()
+
+	res, err := gj.GraphQL(context.Background(), `query {
+		alpha: synthetic_alpha { f: flag_value p: parent_id k: payload_kind }
+		beta: synthetic_beta { f: flag_value p: parent_id }
+	}`, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, res.Errors)
+
+	var out struct {
+		Alpha []struct {
+			Flag    bool   `json:"f"`
+			Parent  int    `json:"p"`
+			Payload string `json:"k"`
+		} `json:"alpha"`
+		Beta []struct {
+			Flag   bool `json:"f"`
+			Parent int  `json:"p"`
+		} `json:"beta"`
+	}
+	require.NoError(t, json.Unmarshal(res.Data, &out))
+	require.Len(t, out.Alpha, 1)
+	require.Len(t, out.Beta, 1)
+	assert.True(t, out.Alpha[0].Flag)
+	assert.Equal(t, 41, out.Alpha[0].Parent)
+	assert.Equal(t, "alpha", out.Alpha[0].Payload)
+	assert.False(t, out.Beta[0].Flag)
+	assert.Equal(t, 73, out.Beta[0].Parent)
+}
+
 // TestMSSQLVariableLimitUnderAnalytics guards #604: with analytics_mode on, a
 // variable limit (limit: $n) must still apply instead of returning all rows.
 func TestMSSQLVariableLimitUnderAnalytics(t *testing.T) {


### PR DESCRIPTION
## Summary

- route configured databases through the established driver initialization path so per-database PostgreSQL TLS, MSSQL encryption, certificates, Snowflake key authentication, and pool settings are honored
- resolve normalized MSSQL column identifiers within their owning table, preventing physical-name collisions across tables
- add synthetic compiler and live SQL Server regressions without retaining identifiers from a reported schema

## Tests

- complete unit sweep across every Go-bearing workspace module
- go test ./serv -run ^TestNewDBFromDatabaseConfigHonorsPostgresTLSValidation$ -count=1
- go test ./core/internal/psql -run ^TestMSSQLIdentifierMappingIsScopedByTable$ -count=1
- go test -v -timeout 30m -race -db=mssql -tags mssql -run ^TestMSSQLMixedColumnSpellingsStayTableScoped$ .

Fixes #564
Fixes #571