### PR TITLE
fix: clear failed remote join markers

### DIFF
--- a/core/remote_join.go
+++ b/core/remote_join.go
@@ -34,9 +34,9 @@ func (s *gstate) execRemoteJoin(c context.Context) (err error) {
 		return
 	}
 
-	to, extra, err := s.resolveRemotes(c, from, sfmap, s.requestedRootCursorFields())
-	if err != nil {
-		return
+	to, extra, resolveErr := s.resolveRemotes(c, from, sfmap, s.requestedRootCursorFields())
+	if resolveErr != nil && len(to) != len(from) {
+		return resolveErr
 	}
 
 	var ob bytes.Buffer
@@ -50,8 +50,11 @@ func (s *gstate) execRemoteJoin(c context.Context) (err error) {
 		}
 		s.dhash = sha256.Sum256(s.data)
 		s.data, err = encryptValues(s.data, s.gj.printFormat, decPrefix, s.dhash[:], s.gj.encryptionKey)
+		if err != nil {
+			return err
+		}
 	}
-	return
+	return resolveErr
 }
 
 // resolveRemotes fetches remote data for the marked insertion points
@@ -106,6 +109,9 @@ func (s *gstate) resolveRemotes(
 		if !ok {
 			return nil, nil, fmt.Errorf("no resolver found for remote %q", rkey)
 		}
+		// Keep a null replacement ready so a resolver failure cannot leak the
+		// internal marker into the partial GraphQL response.
+		to[i] = jsn.Field{Key: []byte(sel.FieldName)}
 
 		go func(n int, id []byte, sel *qcode.Select, r resItem, rkey string) {
 			defer wg.Done()

--- a/core/remote_join_error_test.go
+++ b/core/remote_join_error_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/dosco/graphjin/core/v3/internal/qcode"
+)
+
+type failingRemoteResolver struct{}
+
+func (failingRemoteResolver) Resolve(context.Context, ResolverReq) ([]byte, error) {
+	return nil, errors.New("upstream unavailable")
+}
+
+func TestExecRemoteJoinPreservesHealthyRootsOnResolverError(t *testing.T) {
+	selects := []qcode.Select{{
+		Field: qcode.Field{
+			ParentID:   -1,
+			FieldName:  "automations",
+			SkipRender: qcode.SkipTypeRemote,
+		},
+		Table: "automations",
+		Fields: []qcode.Field{{
+			FieldName: "id",
+		}},
+	}}
+	state := &gstate{
+		gj: &graphjinEngine{
+			trace: &tracer{},
+			rmap: map[string]resItem{
+				"automations": {Fn: failingRemoteResolver{}, Source: "openapi", Scope: "automations"},
+			},
+		},
+		cs: &cstate{st: stmt{qc: &qcode.QCode{
+			Selects: selects,
+			Roots:   []int32{0},
+			Remotes: 1,
+		}}},
+		data: []byte(`{"project":[{"id":"central-ops"}],"automations":"__remote__:automations"}`),
+	}
+
+	err := state.execRemoteJoin(context.Background())
+	if err == nil || err.Error() != "automations: upstream unavailable" {
+		t.Fatalf("execRemoteJoin error = %v", err)
+	}
+
+	var got struct {
+		Project     []map[string]string `json:"project"`
+		Automations json.RawMessage     `json:"automations"`
+	}
+	if err := json.Unmarshal(state.data, &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v\n%s", err, state.data)
+	}
+	if len(got.Project) != 1 || got.Project[0]["id"] != "central-ops" {
+		t.Fatalf("healthy project root was not preserved: %s", state.data)
+	}
+	if string(got.Automations) != "null" {
+		t.Fatalf("failed remote root = %s, want null; response=%s", got.Automations, state.data)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes: When a top-level remote resolver fails in a mixed GraphQL query, Result.Data retains the internal __remote__ marker instead of returning null for the failed root while preserving healthy roots.
- Root cause: resolveRemotes returns both the per-root replacement slice and the resolver error, but execRemoteJoin returned immediately on that error before calling jsn.Replace. The early return therefore left the internal placeholder in the public partial response. Preparing a null replacement for each resolver and deferring only resolver errors until after replacement preserves healthy data, clears the failed slot, and still reports the upstream failure.

## Regression evidence

- Before: `go test ./core -run '^TestExecRemoteJoinPreservesHealthyRootsOnResolverError$' -count=1` exited `1`

- After: `go test ./core -run '^TestExecRemoteJoinPreservesHealthyRootsOnResolverError$' -count=1` exited `0`

## Verification

- `go test ./core -count=1`
- `go test -race ./core -count=1`
- `go test ./auth ./core ./serv -count=1`
- `make -B build`
- `test -z "$(gofmt -d core/remote_join.go core/remote_join_error_test.go)"`
- `git diff --cached --check`

## Scope

- 2 files changed, +73 / -4 lines

## Validation notes

- The Docker-backed database matrix in `make test` was not run because the local Colima daemon was unavailable; the repository-recommended `auth`, `core`, and `serv` package suites passed instead.
- `go vet ./core` reports the same pre-existing lock-copy warning at `core/subs.go:324` on both the exact base SHA and this patch.
