### PR TITLE
fix/improve: eval generator multi-database hardening and scorer corrections

### DIFF
--- a/agent/cmd/skill-eval/data_eval.go
+++ b/agent/cmd/skill-eval/data_eval.go
@@ -332,8 +332,10 @@ func postGraphQL(client *http.Client, profile endpointProfile, query string, var
 	if err != nil {
 		return nil, err
 	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
 	var envelope map[string]any
-	if err := json.Unmarshal(raw, &envelope); err != nil {
+	if err := dec.Decode(&envelope); err != nil {
 		return nil, fmt.Errorf("decode HTTP %d oracle response: %w", status, err)
 	}
 	if errs := toSlice(envelope["errors"]); len(errs) != 0 {
@@ -605,6 +607,7 @@ func evaluateMethod(rule methodRule, answer answerRule, queries, okTools []strin
 	for _, required := range rule.RequireQueryMatch {
 		pattern, err := regexp.Compile("(?i)" + required)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: invalid method regex %q: %v\n", required, err)
 			return false
 		}
 		if !pattern.MatchString(joined) {
@@ -646,7 +649,7 @@ func executedQueries(actions any) ([]string, []string) {
 		if tool != "" {
 			okTools = appendUnique(okTools, tool)
 		}
-		if tool != "execute_graphql" && tool != "execute_saved_query" {
+		if tool != "execute_graphql" && tool != "execute_saved_query" && tool != "execute_sql" && tool != "execute_raw_query" {
 			continue
 		}
 		args := toMap(action["args"])
@@ -883,7 +886,7 @@ func valueString(value any) string {
 
 func numberFromString(text string) (float64, bool) {
 	cleaned := strings.TrimSpace(text)
-	cleaned = strings.TrimPrefix(cleaned, "$")
+	cleaned = strings.ReplaceAll(cleaned, "$", "")
 	cleaned = strings.ReplaceAll(cleaned, ",", "")
 	cleaned = strings.TrimSuffix(cleaned, "%")
 	if cleaned == "" {

--- a/agent/cmd/skill-eval/data_eval_numeric_regression_test.go
+++ b/agent/cmd/skill-eval/data_eval_numeric_regression_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type pr633Transport struct{}
+
+func (pr633Transport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"data":{"amount":9007199254740993}}`))}, nil
+}
+func TestNumberFromStringNegativeCurrency(t *testing.T) {
+	n, ok := numberFromString("-$100.50")
+	if !ok || n != -100.50 {
+		t.Fatalf("got %v, %v", n, ok)
+	}
+}
+func TestPostGraphQLPreservesLargeIntegers(t *testing.T) {
+	data, err := postGraphQL(&http.Client{Transport: pr633Transport{}}, endpointProfile{URL: "http://example.test/api/v1/agent"}, "query { amount }", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := valueString(data.(map[string]any)["amount"]); got != "9007199254740993" {
+		t.Fatalf("got %s", got)
+	}
+}

--- a/agent/eval/generate.go
+++ b/agent/eval/generate.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	mathrand "math/rand"
 	"net/http"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -452,15 +453,18 @@ func (g Generator) VerifyTasks(ctx context.Context, candidates []Task, seed int6
 	}
 	verified := make([]Task, 0, len(candidates))
 	seen := map[string]struct{}{}
+	var droppedNorm, droppedDuplicate, droppedUnresolvedOracle, droppedUselessMutation, droppedBadCollateral int
 	for i := range candidates {
 		if candidates[i].Provenance.Seed == 0 {
 			candidates[i].Provenance.Seed = seed
 		}
 		if err := candidates[i].Normalize(); err != nil {
+			droppedNorm++
 			continue
 		}
 		key := taskStructureKey(candidates[i])
 		if _, ok := seen[key]; ok {
+			droppedDuplicate++
 			continue
 		}
 		if candidates[i].Oracle != nil {
@@ -468,6 +472,7 @@ func (g Generator) VerifyTasks(ctx context.Context, candidates []Task, seed int6
 				return nil, fmt.Errorf("generator needs an oracle verifier")
 			}
 			if !resolved[i] {
+				droppedUnresolvedOracle++
 				continue
 			}
 		}
@@ -479,6 +484,7 @@ func (g Generator) VerifyTasks(ctx context.Context, candidates []Task, seed int6
 			// agent that did nothing at all.
 			baseline, err := g.Verifier.Resolve(ctx, candidates[i].Mutation.PostState)
 			if err != nil || baseline.Value == candidates[i].Mutation.ExpectedValue {
+				droppedUselessMutation++
 				continue
 			}
 			validCollateral := true
@@ -489,11 +495,16 @@ func (g Generator) VerifyTasks(ctx context.Context, candidates []Task, seed int6
 				}
 			}
 			if !validCollateral {
+				droppedBadCollateral++
 				continue
 			}
 		}
 		seen[key] = struct{}{}
 		verified = append(verified, candidates[i])
+	}
+	droppedTotal := droppedNorm + droppedDuplicate + droppedUnresolvedOracle + droppedUselessMutation + droppedBadCollateral
+	if droppedTotal > 0 {
+		fmt.Fprintf(os.Stderr, "Dropped %d candidates: %d normalization errors, %d duplicates, %d unresolved oracles, %d useless mutations, %d bad collateral\n", droppedTotal, droppedNorm, droppedDuplicate, droppedUnresolvedOracle, droppedUselessMutation, droppedBadCollateral)
 	}
 	return verified, nil
 }
@@ -510,11 +521,12 @@ type generatorColumn struct {
 }
 
 type generatorTable struct {
-	Name        string
-	ID          string
-	Columns     []generatorColumn
-	PrimaryKey  string
-	LabelColumn string
+	Name         string
+	ID           string
+	Columns      []generatorColumn
+	PrimaryKey   string
+	CompositeKey bool
+	LabelColumn  string
 }
 
 func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
@@ -526,11 +538,24 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 	}
 	var tasks []Task
 	for _, table := range tables {
-		pk := table.PrimaryKey
-		if pk == "" && len(table.Columns) != 0 {
-			pk = table.Columns[0].Name
+		if isReservedWord(table.Name) {
+			continue
 		}
+		pk := table.PrimaryKey
 		if pk == "" {
+			for _, col := range table.Columns {
+				lower := strings.ToLower(col.Name)
+				if isIntegerLikeType(col.Type) && (strings.HasSuffix(lower, "_id") || strings.HasSuffix(lower, "_key") || lower == "id") {
+					pk = col.Name
+					break
+				}
+			}
+			// Final fallback to first column only if nothing better found
+			if pk == "" && len(table.Columns) != 0 {
+				pk = table.Columns[0].Name
+			}
+		}
+		if pk == "" || isReservedWord(pk) {
 			continue
 		}
 		tasks = append(tasks, generatedTask(seed, table.ID, table.ID, CategoryAggregate, DifficultyT1,
@@ -538,6 +563,9 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 			fmt.Sprintf("query { %s { count_%s } }", table.Name, pk), table.Name+".0.count_"+pk,
 			"number", []string{aggregateMethodPattern("count", pk)}))
 		for _, column := range table.Columns {
+			if isReservedWord(column.Name) {
+				continue
+			}
 			if !isIdentifierColumn(table, column) {
 				completenessQuery := fmt.Sprintf("query { %s(where: {not: {%s: {is_null: true}}}) { count_%s } }", table.Name, column.Name, pk)
 				tasks = append(tasks, generatedTask(seed, table.ID+":"+column.Name, column.ID, CategoryDiscovery, DifficultyT2,
@@ -546,6 +574,9 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 			}
 			if isNumericType(column.Type) && !isIdentifierColumn(table, column) {
 				for _, fn := range []string{"sum", "avg", "min", "max"} {
+					if (fn == "sum" || fn == "avg") && !isSafeSumType(column.Type) {
+						continue
+					}
 					field := fn + "_" + column.Name
 					tasks = append(tasks, generatedTask(seed, table.ID+":"+column.Name, column.ID, CategoryAggregate, DifficultyT1,
 						fmt.Sprintf("What is the %s %s across all %s?", aggregatePhrase(fn), humanize(column.Name), humanize(table.Name)),
@@ -553,7 +584,7 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 						"number", []string{aggregateMethodPattern(fn, column.Name)}))
 				}
 				label := table.LabelColumn
-				if label != "" && label != column.Name {
+				if label != "" && label != column.Name && !table.CompositeKey {
 					tasks = append(tasks,
 						generatedRankingTask(seed, table, column, label, "desc", "highest"),
 						generatedRankingTask(seed, table, column, label, "asc", "lowest"),
@@ -569,7 +600,7 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 					fmt.Sprintf("What is the latest date recorded in %s.%s?", table.Name, column.Name),
 					fmt.Sprintf("query { %s { %s } }", table.Name, field), table.Name+".0."+field,
 					"date", []string{latestDateMethodPattern(column.Name)}))
-				if table.LabelColumn != "" && table.LabelColumn != column.Name {
+				if table.LabelColumn != "" && table.LabelColumn != column.Name && !table.CompositeKey {
 					tasks = append(tasks,
 						generatedRankingTask(seed, table, column, table.LabelColumn, "desc", "latest"),
 						generatedRankingTask(seed, table, column, table.LabelColumn, "asc", "earliest"),
@@ -1296,6 +1327,7 @@ func mergeTableDetails(table *generatorTable, raw any) {
 		}
 		if keys := toSlice(mapValue(details, "primary_keys", "primaryKeys")); len(keys) != 0 {
 			table.PrimaryKey = valueString(keys[0])
+			table.CompositeKey = len(keys) > 1
 		}
 		name := mapString(details, "column_name", "columnName")
 		if name == "" {
@@ -1468,6 +1500,13 @@ func mapBool(values map[string]any, keys ...string) bool {
 
 func normalizeDetailKey(value string) string {
 	return strings.ToLower(strings.ReplaceAll(value, "_", ""))
+}
+
+func isSafeSumType(colType string) bool {
+	t := strings.ToLower(colType)
+	return t == "bigint" || t == "decimal" || t == "numeric" || t == "float" ||
+		t == "real" || t == "double" || t == "double precision" ||
+		t == "money" || t == "smallmoney" || t == "float8" || t == "float4"
 }
 
 func isNumericType(value string) bool {
@@ -1821,4 +1860,20 @@ func twinsForSelectedNeeds(selected, twins []Task) []Task {
 		}
 	}
 	return out
+}
+
+func isReservedWord(name string) bool {
+	switch strings.ToLower(name) {
+	case "as", "order", "select", "from", "where", "table", "column", "group", "having", "join", "on", "in", "not", "and", "or", "like", "between", "case", "when", "then", "else", "end", "null", "true", "false", "is", "set", "key", "index", "primary", "foreign", "create", "drop", "alter", "insert", "update", "delete", "into", "values", "default", "check", "constraint", "references", "unique", "date", "time", "timestamp", "type", "name", "value", "status", "level", "role", "user", "grant", "revoke", "public", "schema", "database", "desc", "asc":
+		return true
+	}
+	return false
+}
+
+func isIntegerLikeType(typeName string) bool {
+	switch strings.ToLower(typeName) {
+	case "int", "integer", "bigint", "smallint", "tinyint", "serial", "number":
+		return true
+	}
+	return false
 }

--- a/agent/eval/generate.go
+++ b/agent/eval/generate.go
@@ -537,10 +537,10 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 		profile.ReadOnly = profile.ReadOnly || snapshot.Status.ReadOnly
 	}
 	var tasks []Task
+	// Let live oracle verification reject unsupported queries or overflowing
+	// aggregates. SQL keyword and type blacklists would also discard valid
+	// tasks on databases that quote identifiers or promote aggregate types.
 	for _, table := range tables {
-		if isReservedWord(table.Name) {
-			continue
-		}
 		pk := table.PrimaryKey
 		if pk == "" {
 			for _, col := range table.Columns {
@@ -555,7 +555,7 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 				pk = table.Columns[0].Name
 			}
 		}
-		if pk == "" || isReservedWord(pk) {
+		if pk == "" {
 			continue
 		}
 		tasks = append(tasks, generatedTask(seed, table.ID, table.ID, CategoryAggregate, DifficultyT1,
@@ -563,9 +563,6 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 			fmt.Sprintf("query { %s { count_%s } }", table.Name, pk), table.Name+".0.count_"+pk,
 			"number", []string{aggregateMethodPattern("count", pk)}))
 		for _, column := range table.Columns {
-			if isReservedWord(column.Name) {
-				continue
-			}
 			if !isIdentifierColumn(table, column) {
 				completenessQuery := fmt.Sprintf("query { %s(where: {not: {%s: {is_null: true}}}) { count_%s } }", table.Name, column.Name, pk)
 				tasks = append(tasks, generatedTask(seed, table.ID+":"+column.Name, column.ID, CategoryDiscovery, DifficultyT2,
@@ -574,9 +571,6 @@ func generateCatalogCandidates(snapshot CatalogSnapshot, seed int64) []Task {
 			}
 			if isNumericType(column.Type) && !isIdentifierColumn(table, column) {
 				for _, fn := range []string{"sum", "avg", "min", "max"} {
-					if (fn == "sum" || fn == "avg") && !isSafeSumType(column.Type) {
-						continue
-					}
 					field := fn + "_" + column.Name
 					tasks = append(tasks, generatedTask(seed, table.ID+":"+column.Name, column.ID, CategoryAggregate, DifficultyT1,
 						fmt.Sprintf("What is the %s %s across all %s?", aggregatePhrase(fn), humanize(column.Name), humanize(table.Name)),
@@ -1320,14 +1314,23 @@ func catalogTables(rows []CatalogRow) []generatorTable {
 }
 
 func mergeTableDetails(table *generatorTable, raw any) {
+	primaryKeys := map[string]struct{}{}
+	if table.PrimaryKey != "" {
+		primaryKeys[table.PrimaryKey] = struct{}{}
+	}
 	walkDetailMaps(raw, func(details map[string]any) {
 		value, _ := mapValue(details, "primary_key", "primaryKey").(string)
 		if value = strings.TrimSpace(value); value != "" {
 			table.PrimaryKey = value
+			primaryKeys[value] = struct{}{}
 		}
 		if keys := toSlice(mapValue(details, "primary_keys", "primaryKeys")); len(keys) != 0 {
 			table.PrimaryKey = valueString(keys[0])
-			table.CompositeKey = len(keys) > 1
+			for _, key := range keys {
+				if name := strings.TrimSpace(valueString(key)); name != "" {
+					primaryKeys[name] = struct{}{}
+				}
+			}
 		}
 		name := mapString(details, "column_name", "columnName")
 		if name == "" {
@@ -1340,8 +1343,10 @@ func mergeTableDetails(table *generatorTable, raw any) {
 		})
 		if mapBool(details, "primary", "primary_key", "primaryKey") {
 			table.PrimaryKey = name
+			primaryKeys[name] = struct{}{}
 		}
 	})
+	table.CompositeKey = table.CompositeKey || len(primaryKeys) > 1
 }
 
 func appendColumn(columns []generatorColumn, value generatorColumn) []generatorColumn {
@@ -1500,13 +1505,6 @@ func mapBool(values map[string]any, keys ...string) bool {
 
 func normalizeDetailKey(value string) string {
 	return strings.ToLower(strings.ReplaceAll(value, "_", ""))
-}
-
-func isSafeSumType(colType string) bool {
-	t := strings.ToLower(colType)
-	return t == "bigint" || t == "decimal" || t == "numeric" || t == "float" ||
-		t == "real" || t == "double" || t == "double precision" ||
-		t == "money" || t == "smallmoney" || t == "float8" || t == "float4"
 }
 
 func isNumericType(value string) bool {
@@ -1860,14 +1858,6 @@ func twinsForSelectedNeeds(selected, twins []Task) []Task {
 		}
 	}
 	return out
-}
-
-func isReservedWord(name string) bool {
-	switch strings.ToLower(name) {
-	case "as", "order", "select", "from", "where", "table", "column", "group", "having", "join", "on", "in", "not", "and", "or", "like", "between", "case", "when", "then", "else", "end", "null", "true", "false", "is", "set", "key", "index", "primary", "foreign", "create", "drop", "alter", "insert", "update", "delete", "into", "values", "default", "check", "constraint", "references", "unique", "date", "time", "timestamp", "type", "name", "value", "status", "level", "role", "user", "grant", "revoke", "public", "schema", "database", "desc", "asc":
-		return true
-	}
-	return false
 }
 
 func isIntegerLikeType(typeName string) bool {

--- a/agent/eval/generate_catalog_regression_test.go
+++ b/agent/eval/generate_catalog_regression_test.go
@@ -1,0 +1,75 @@
+package eval
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCatalogCandidatesPreserveIntegerAggregatesAndCommonNames(t *testing.T) {
+	rows := []CatalogRow{{ID: "table:app:main.orders", Kind: "table", TableName: "orders", DetailsJSON: `[{"ColumnName":"id","Type":"integer","PrimaryKey":true},{"ColumnName":"name","Type":"text"},{"ColumnName":"amount_cents","Type":"integer"}]`}}
+	tasks := generateCatalogCandidates(CatalogSnapshot{Rows: rows}, 23)
+	for _, field := range []string{"sum_amount_cents", "avg_amount_cents", "name: {is_null: true}"} {
+		found := false
+		for _, task := range tasks {
+			if task.Oracle != nil && strings.Contains(task.Oracle.Query, field) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("lost valid catalog task containing %q", field)
+		}
+	}
+}
+func TestCatalogCandidatesSkipCompositeKeyRankings(t *testing.T) {
+	rows := []CatalogRow{{ID: "table:app:main.orders", Kind: "table", TableName: "orders", DetailsJSON: `[{"ColumnName":"order_id","Type":"integer","PrimaryKey":true},{"ColumnName":"line_id","Type":"integer","PrimaryKey":true},{"ColumnName":"name","Type":"text"},{"ColumnName":"amount","Type":"decimal"}]`}}
+	tables := catalogTables(rows)
+	if len(tables) != 1 || !tables[0].CompositeKey {
+		t.Fatalf("composite key metadata missing: %+v", tables)
+	}
+	for _, task := range generateCatalogCandidates(CatalogSnapshot{Rows: rows}, 23) {
+		if task.Category == CategoryRanking {
+			t.Errorf("composite key still produces ranking: %s", task.Oracle.Query)
+		}
+	}
+}
+
+func TestCatalogTablesPrimaryKeyRepresentations(t *testing.T) {
+	for _, tc := range []struct {
+		name, details string
+		composite     bool
+	}{
+		{"sectioned composite", `[{"section":"key_columns","data_json":"{\"columns\":[{\"ColumnName\":\"order_id\",\"Type\":\"integer\",\"PrimaryKey\":true},{\"ColumnName\":\"line_id\",\"Type\":\"integer\",\"PrimaryKey\":true}]}"}]`, true},
+		{"explicit composite", `{"primary_keys":["order_id","line_id"]}`, true},
+		{"repeated single key", `[{"primary_key":"id"},{"primary_keys":["id"]},{"ColumnName":"id","PrimaryKey":true},{"ColumnName":"id","PrimaryKey":true}]`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tables := catalogTables([]CatalogRow{{ID: "table:orders", Kind: "table", TableName: "orders", DetailsJSON: tc.details}})
+			if len(tables) != 1 || tables[0].CompositeKey != tc.composite {
+				t.Fatalf("key metadata: %+v", tables)
+			}
+		})
+	}
+}
+
+func TestCatalogCandidatesPreserveQuotedTableAndParameterizedTypes(t *testing.T) {
+	for _, typ := range []string{"integer", "numeric(18,2)", "decimal(18,2)", "number"} {
+		t.Run(typ, func(t *testing.T) {
+			rows := []CatalogRow{{ID: "table:order", Kind: "table", TableName: "order", DetailsJSON: []any{
+				map[string]any{"ColumnName": "key", "Type": "integer", "PrimaryKey": true},
+				map[string]any{"ColumnName": "value", "Type": typ},
+			}}}
+			tasks := generateCatalogCandidates(CatalogSnapshot{Rows: rows}, 23)
+			for _, field := range []string{"count_key", "sum_value", "avg_value"} {
+				found := false
+				for _, task := range tasks {
+					if task.Oracle != nil && strings.Contains(task.Oracle.Query, field) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("missing %s for %s", field, typ)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix scorer failures for negative currency such as `-$100.50` and preserve large integer oracle values during JSON decoding. Improve catalog-derived evaluation tasks by detecting composite primary keys from both explicit key arrays and the catalog's per-column `PrimaryKey` flags, and prefer integer ID/key columns when no primary key is supplied.

Candidate generation preserves common table/column names and integer or parameterized numeric aggregates. Existing live oracle verification rejects unsupported queries and database-specific aggregate overflow; global SQL keyword and numeric-type blacklists would discard valid tasks on other databases.

Retain categorized dropped-candidate diagnostics, invalid method-regex warnings, and recognition of SQL execution tools in method evaluation. Composite-key tables skip ranking tasks that cannot identify a row using a single key.

## Validation

Regression tests cover negative currency, exact large-integer oracle decoding, integer and parameterized numeric aggregate coverage, common SQL-like names, composite-key catalog formats, and duplicate descriptions of a single key.

The original scorer failures were reproduced on the base. The original PR's coverage regression and incomplete composite-key handling were reproduced with targeted tests.

`go test ./agent/...` passes on updated head `0832e4b9`. GitHub's Build run is awaiting contributor-workflow approval.
